### PR TITLE
pltbrowser: add sorting when clicking column header and fix manual sorting with dnd

### DIFF
--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -490,7 +490,7 @@ add_treeview_column (w_pltbrowser_t *w, GtkTreeView *tree, int pos, int expand, 
     return col;
 }
 
-static gboolean draw_row_active = FALSE;
+static gboolean drag_row_active = FALSE;
 
 static gboolean
 on_pltbrowser_drag_begin_event          (GtkWidget       *widget,
@@ -500,7 +500,7 @@ on_pltbrowser_drag_begin_event          (GtkWidget       *widget,
                                         guint            time,
                                         gpointer user_data)
 {
-    draw_row_active = TRUE;
+    drag_row_active = TRUE;
 }
 
 static gboolean
@@ -511,7 +511,7 @@ on_pltbrowser_drag_end_event          (GtkWidget       *widget,
                                         guint            time,
                                         gpointer user_data)
 {
-    draw_row_active = FALSE;
+    drag_row_active = FALSE;
 }
 
 static gboolean
@@ -523,7 +523,7 @@ on_pltbrowser_drag_motion_event          (GtkWidget       *widget,
                                         gpointer user_data)
 {
     w_pltbrowser_t *w = user_data;
-    if (draw_row_active) {
+    if (drag_row_active) {
         return FALSE;
     }
     GdkWindow *window = gtk_tree_view_get_bin_window (GTK_TREE_VIEW (widget));

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -490,6 +490,30 @@ add_treeview_column (w_pltbrowser_t *w, GtkTreeView *tree, int pos, int expand, 
     return col;
 }
 
+static gboolean draw_row_active = FALSE;
+
+static gboolean
+on_pltbrowser_drag_begin_event          (GtkWidget       *widget,
+                                        GdkDragContext  *drag_context,
+                                        gint             x,
+                                        gint             y,
+                                        guint            time,
+                                        gpointer user_data)
+{
+    draw_row_active = TRUE;
+}
+
+static gboolean
+on_pltbrowser_drag_end_event          (GtkWidget       *widget,
+                                        GdkDragContext  *drag_context,
+                                        gint             x,
+                                        gint             y,
+                                        guint            time,
+                                        gpointer user_data)
+{
+    draw_row_active = FALSE;
+}
+
 static gboolean
 on_pltbrowser_drag_motion_event          (GtkWidget       *widget,
                                         GdkDragContext  *drag_context,
@@ -499,6 +523,9 @@ on_pltbrowser_drag_motion_event          (GtkWidget       *widget,
                                         gpointer user_data)
 {
     w_pltbrowser_t *w = user_data;
+    if (draw_row_active) {
+        return FALSE;
+    }
     GdkWindow *window = gtk_tree_view_get_bin_window (GTK_TREE_VIEW (widget));
 
     int bin_x = 0;
@@ -671,6 +698,12 @@ w_pltbrowser_create (void) {
             w);
     g_signal_connect ((gpointer) w->tree, "row_activated",
             G_CALLBACK (on_pltbrowser_row_activated),
+            w);
+    g_signal_connect ((gpointer) w->tree, "drag_begin",
+            G_CALLBACK (on_pltbrowser_drag_begin_event),
+            w);
+    g_signal_connect ((gpointer) w->tree, "drag_end",
+            G_CALLBACK (on_pltbrowser_drag_end_event),
             w);
     g_signal_connect ((gpointer) w->tree, "drag_motion",
             G_CALLBACK (on_pltbrowser_drag_motion_event),


### PR DESCRIPTION
I couldn't find a nice and reliable way to do the column sorting with gtk's sortable interface so I went with a slightly different approach where I sort the playlists on column click and  then update the treeview. Hope that's ok.