### PR TITLE
ddbtabstrip: add min/max tab size as #defines in header (no more change to ddbtabstrip.c req'd)

### DIFF
--- a/plugins/gtkui/ddbtabstrip.c
+++ b/plugins/gtkui/ddbtabstrip.c
@@ -318,8 +318,8 @@ static int text_right_padding = 0; // calculated from widget height
 static int text_vert_offset = -2;
 static int tab_overlap_size = 0; // widget_height/2
 static int tabs_left_margin = 4;
-static int min_tab_size = 80;
-static int max_tab_size = 200;
+static int min_tab_size = DDB_TABSTRIP_MIN_TAB_SIZE;
+static int max_tab_size = DDB_TABSTRIP_MAX_TAB_SIZE;
 
 static int tab_moved = 0;
 

--- a/plugins/gtkui/ddbtabstrip.h
+++ b/plugins/gtkui/ddbtabstrip.h
@@ -31,6 +31,9 @@ G_BEGIN_DECLS
 #define DDB_IS_TABSTRIP_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE ((obj), DDB_TYPE_TABSTRIP))
 #define DDB_TABSTRIP_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), DDB_TYPE_TABSTRIP, DdbTabStripClass))
 
+#define DDB_TABSTRIP_MIN_TAB_SIZE 80
+#define DDB_TABSTRIP_MAX_TAB_SIZE 200
+
 typedef struct _DdbTabStrip DdbTabStrip;
 typedef struct _DdbTabStripClass DdbTabStripClass;
 


### PR DESCRIPTION
Hi Alexey

hey this is my first PR :) Moved hardcoded values of min_tab_size / max_tab_size out of `ddbtabstrip.c` and set #defines in the header file accordingly.
Note this is only an example. Maybe it would make sense to also have margin, v-align etc. values as #defines - but I've decided to stick to these two most important (and most prone-for-tweaking) ones.