### PR TITLE
Refactor album art drawing in listview and expand tabs in gtk3 ui

### DIFF
--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -97,9 +97,9 @@ ddb_listview_list_render (DdbListview *ps, cairo_t *cr, int x, int y, int w, int
 void
 ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h);
 void
-ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, DdbListviewIter group_it, int even, int cursor, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int w, int h);
+ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h);
 void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter it, DdbListviewIter group_it, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int w, int h);
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter group_it, int group_pinned, int grp_next_y, int x, int y, int w, int h);
 void
 ddb_listview_list_track_dragdrop (DdbListview *ps, int y);
 int
@@ -801,7 +801,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
                 cairo_rectangle (cr, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
                 cairo_fill (cr);
                 ddb_listview_list_render_row_background (listview, cr, it, i & 1, (abs_idx+i) == listview->binding->cursor () ? 1 : 0, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
-                ddb_listview_list_render_row_foreground (listview, cr, it, grp->head, (idx + 1 + i) & 1, (idx+i) == listview->binding->cursor () ? 1 : 0, i * listview->rowheight, grp->height, grp->pinned, grp_next_y - listview->scrollpos, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
+                ddb_listview_list_render_row_foreground (listview, cr, it, (idx + 1 + i) & 1, (idx+i) == listview->binding->cursor () ? 1 : 0, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
             }
             DdbListviewIter next = listview->binding->next (it);
             listview->binding->unref (it);
@@ -830,11 +830,10 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
                 cairo_rectangle (cr, x, grp_y - listview->scrollpos + grp_height, w, filler);
                 cairo_fill (cr);
             }
-            //ddb_listview_list_render_row_foreground (listview, cr, NULL, grp->head, 0, 0, grp->num_items * listview->rowheight, grp->height, grp->pinned, grp_next_y - listview->scrollpos, -listview->hscrollpos, grp_y - listview->scrollpos + grp_height, listview->totalwidth, filler);
         }
 
         // draw album art
-        ddb_listview_list_render_album_art (listview, cr, it, grp->head, 0, grp->height, grp->pinned, grp_next_y - listview->scrollpos, -listview->hscrollpos, grp_y + listview->grouptitle_height - listview->scrollpos, listview->totalwidth, grp_height_total);
+        ddb_listview_list_render_album_art (listview, cr, grp->head, grp->pinned, grp_next_y - listview->scrollpos, -listview->hscrollpos, grp_y + listview->grouptitle_height - listview->scrollpos, listview->totalwidth, grp_height_total);
         if (grp->pinned == 1 && gtkui_groups_pinned && y <= 0) {
             // draw pinned group title
             int pushback = 0;
@@ -1448,7 +1447,7 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
 }
 
 void
-ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, DdbListviewIter group_it, int even, int cursor, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int w, int h) {
+ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h) {
     int width, height;
     GtkAllocation a;
     gtk_widget_get_allocation (ps->list, &a);
@@ -1469,20 +1468,20 @@ ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListvi
     for (c = ps->columns; c; c = c->next, cidx++) {
         int cw = c->width;
         if (!ddb_listview_is_album_art_column_idx (ps, cidx)) {
-            ps->binding->draw_column_data (ps, cr, it, ps->grouptitle_height > 0 ? group_it : NULL, cidx, group_y, group_height, group_pinned, grp_next_y, x, y, cw, h);
+            ps->binding->draw_column_data (ps, cr, it, cidx, x, y, cw, h);
         }
         x += cw;
     }
 }
 
 void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter it, DdbListviewIter group_it, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int w, int h) {
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter group_it, int group_pinned, int grp_next_y, int x, int y, int w, int h) {
     DdbListviewColumn *c;
     int cidx = 0;
     for (c = ps->columns; c; c = c->next, cidx++) {
         int cw = c->width;
         if (ddb_listview_is_album_art_column_idx (ps, cidx)) {
-            ps->binding->draw_column_data (ps, cr, it, ps->grouptitle_height > 0 ? group_it : NULL, cidx, group_y, group_height, group_pinned, grp_next_y, x, y, cw, h);
+            ps->binding->draw_album_art (ps, cr, ps->grouptitle_height > 0 ? group_it : NULL, cidx, group_pinned, grp_next_y, x, y, cw, h);
         }
         x += cw;
     }

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -93,7 +93,8 @@ typedef struct {
 
     // callbacks
     void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int x, int y, int width, int height);
-    void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, DdbListviewIter group_iter, int column, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+    void (*draw_album_art) (DdbListview *listview, cairo_t *drawable, DdbListviewIter group_iter, int column, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+    void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int column, int x, int y, int width, int height);
     void (*list_context_menu) (DdbListview *listview, DdbListviewIter iter, int idx);
     void (*header_context_menu) (DdbListview *listview, int col);
     void (*handle_doubleclick) (DdbListview *listview, DdbListviewIter iter, int idx);

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -257,6 +257,7 @@ DdbListviewBinding main_binding = {
     .external_drag_n_drop = main_external_drag_n_drop,
 
     .draw_column_data = draw_column_data,
+    .draw_album_art = draw_album_art,
     .draw_group_title = pl_common_draw_group_title,
 
     // columns

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -24,7 +24,11 @@
 int
 rewrite_column_config (DdbListview *listview, const char *name);
 
-void draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, DdbListviewIter group_it, int column, int group_y, int group_height, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+void
+draw_album_art (DdbListview *listview, cairo_t *drawable, DdbListviewIter group_it, int column, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+
+void
+draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int column, int x, int y, int width, int height);
 
 void
 list_context_menu (DdbListview *listview, DdbListviewIter it, int idx);

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -392,6 +392,7 @@ static DdbListviewBinding search_binding = {
     .external_drag_n_drop = NULL,
 
     .draw_column_data = draw_column_data,
+    .draw_album_art = draw_album_art,
     .draw_group_title = pl_common_draw_group_title,
 
     // columns

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -1604,6 +1604,15 @@ on_move_tab_left_activate (GtkMenuItem *menuitem, gpointer user_data) {
             gtk_widget_show (newchild->widget);
 
             gtk_notebook_insert_page (GTK_NOTEBOOK (w->base.widget), newchild->widget, label, w->clicked_page-1);
+#if GTK_CHECK_VERSION(3,0,0)
+            gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
+            gtk_misc_set_padding (GTK_MISC (label), 0, 0);
+            gtk_container_child_set (GTK_CONTAINER (w->base.widget),
+                    newchild->widget,
+                    "tab-expand", TRUE,
+                    "tab-fill", TRUE,
+                    NULL);
+#endif
             gtk_notebook_set_current_page (GTK_NOTEBOOK (w->base.widget), w->clicked_page-1);
             w->clicked_page--;
             break;
@@ -1684,6 +1693,15 @@ w_tabs_add (ddb_gtkui_widget_t *cont, ddb_gtkui_widget_t *child) {
     gtk_widget_show (label);
     gtk_widget_show (child->widget);
     gtk_notebook_append_page (GTK_NOTEBOOK (cont->widget), child->widget, label);
+#if GTK_CHECK_VERSION(3,0,0)
+    gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
+    gtk_misc_set_padding (GTK_MISC (label), 0, 0);
+    gtk_container_child_set (GTK_CONTAINER (cont->widget),
+                           child->widget,
+                           "tab-expand", TRUE,
+                           "tab-fill", TRUE,
+                           NULL);
+#endif
 }
 
 static void
@@ -1707,6 +1725,15 @@ w_tabs_replace (ddb_gtkui_widget_t *cont, ddb_gtkui_widget_t *child, ddb_gtkui_w
             gtk_widget_show (label);
             gtk_widget_show (newchild->widget);
             int pos = gtk_notebook_insert_page (GTK_NOTEBOOK (cont->widget), newchild->widget, label, ntab);
+#if GTK_CHECK_VERSION(3,0,0)
+            gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
+            gtk_misc_set_padding (GTK_MISC (label), 0, 0);
+            gtk_container_child_set (GTK_CONTAINER (cont->widget),
+                           newchild->widget,
+                           "tab-expand", TRUE,
+                           "tab-fill", TRUE,
+                           NULL);
+#endif
             gtk_notebook_set_current_page (GTK_NOTEBOOK (cont->widget), pos);
             break;
         }
@@ -1798,6 +1825,11 @@ w_tabs_init (ddb_gtkui_widget_t *base) {
             GtkWidget *child = gtk_notebook_get_nth_page (GTK_NOTEBOOK (w->base.widget), page);
             if (w->titles[page]) {
                 gtk_notebook_set_tab_label_text (GTK_NOTEBOOK (w->base.widget), child, w->titles[page]);
+#if GTK_CHECK_VERSION(3,0,0)
+                GtkLabel *label = gtk_notebook_get_tab_label (GTK_NOTEBOOK (w->base.widget), child);
+                gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
+                gtk_misc_set_padding (GTK_MISC (label), 0, 0);
+#endif
             }
             page++;
         }


### PR DESCRIPTION
Goals of album art refactoring:
- get rid of too long argument lists
- reduce length of draw_column_data
- remove unnecessary variables
- avoid code duplication (cairo_rectangle calls)