### PR TITLE
Fix for uninitialized GError

### DIFF
--- a/plugins/statusnotifier/ddb_statusnotifier.c
+++ b/plugins/statusnotifier/ddb_statusnotifier.c
@@ -123,7 +123,7 @@ static void notifier_initialize_status_icon(char * iconstr) {
 }
 
 static void notifier_create_status_icon_from_file(char * iconfile) {
-    GError *err;
+    GError *err = NULL;
     GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file (iconfile, &err);
     notifier = sn_create_with_icondata("deadbeef-notifier",ApplicationStatus,pixbuf);
     sn_set_tooltip_icondata(notifier,pixbuf);


### PR DESCRIPTION
Hopefully, this should fix the problem.
My guess is that the compiler on my machine sets that variable to zero, while the compiler on drone.io did not (it may also be due to different optimization levels).
This should fix the issue.