### PR TITLE
Read plugins dir from DEADBEEF_PLUGIN_DIR if available

### DIFF
--- a/main.c
+++ b/main.c
@@ -912,7 +912,15 @@ main (int argc, char *argv[]) {
             fprintf (stderr, "fatal: too long install path %s\n", dbinstalldir);
             return -1;
         }
-        if (snprintf (dbplugindir, sizeof (dbplugindir), "%s/deadbeef", LIBDIR) > sizeof (dbplugindir)) {
+        char *env_plugin_dir = getenv ("DEADBEEF_PLUGIN_DIR");
+        if (env_plugin_dir) {
+            strncpy (dbplugindir, env_plugin_dir, sizeof(dbplugindir));
+            if (dbplugindir[sizeof(dbplugindir) - 1] != 0) {
+                fprintf (stderr, "fatal: too long plugin path %s\n", env_plugin_dir);
+                return -1;
+            }
+        }
+        else if (snprintf (dbplugindir, sizeof (dbplugindir), "%s/deadbeef", LIBDIR) > sizeof (dbplugindir)) {
             fprintf (stderr, "fatal: too long install path %s\n", dbinstalldir);
             return -1;
         }


### PR DESCRIPTION
This would allow to use plugins in environments such as Nix/NixOS. Nix package manager places packages into separated immutable directories, so we can't add any plugins to the deadbeef installation prefix. Usual way to deal with this is to pass path to the plugins in an environment variable.