### PR TITLE
statusnotifier: fix crash when re-enabling plugin

### DIFF
--- a/plugins/statusnotifier/ddb_statusnotifier.c
+++ b/plugins/statusnotifier/ddb_statusnotifier.c
@@ -50,6 +50,7 @@ sn_plugin_stop (void) {
         sn_destroy (notifier);
     }
     notifier = NULL;
+    sn_finalize();
     return 0;
 }
 

--- a/plugins/statusnotifier/statusnotifier.c
+++ b/plugins/statusnotifier/statusnotifier.c
@@ -347,11 +347,12 @@ static void
 on_name_lost(GDBusConnection *connection, const gchar *name, gpointer user_data);
 
 void sn_register_item(StatusNotifierItem *this) {
-    if (introspection_data)
-        g_dbus_node_info_ref(introspection_data);
-    else
+    if (!introspection_data)
         introspection_data = g_dbus_node_info_new_for_xml(introspection_xml,
                 NULL);
+    //if there is only 1 instance, refcount is 2: it is released only by explicit
+    //call to sn_finalize()
+    g_dbus_node_info_ref(introspection_data);
 
     g_assert(introspection_data != NULL);
 
@@ -440,6 +441,12 @@ void sn_destroy(gpointer data) {
     sn_seticondata(&this->tooltip.icondata, NULL);
     sn_setstr(&this->tooltip.title, NULL);
     sn_setstr(&this->tooltip.text, NULL);
+}
+
+void sn_finalize() {
+    if (introspection_data)
+        g_dbus_node_info_unref(introspection_data);
+    introspection_data = NULL;
 }
 
 void sn_hook_on_context_menu(StatusNotifierItem *this, cb_context_menu cb) {

--- a/plugins/statusnotifier/statusnotifier.h
+++ b/plugins/statusnotifier/statusnotifier.h
@@ -58,6 +58,7 @@ typedef void (*cb_destroy_regerr_data) (void *data);
 StatusNotifierItem *sn_create_with_iconname(const gchar *id, SN_CATEGORY category, const gchar *iconname);
 StatusNotifierItem *sn_create_with_icondata(const gchar *id, SN_CATEGORY category, GdkPixbuf *icondata);
 void sn_destroy (gpointer data);
+void sn_finalize();
 
 void sn_set_title(StatusNotifierItem *this, const gchar *title);
 void sn_set_status(StatusNotifierItem *this, SN_STATUS status);


### PR DESCRIPTION
This fixes the crash when the plugin in disabled and then re-enabled.