### PR TITLE
Fix widget artwork scaling for non-square images

### DIFF
--- a/plugins/gtkui/coverart.c
+++ b/plugins/gtkui/coverart.c
@@ -252,7 +252,15 @@ cache_qsort(const void *a, const void *b)
     const cached_pixbuf_t *y = (cached_pixbuf_t *)b;
     if (x->pixbuf && y->pixbuf) {
         const int cmp = strcmp(x->fname, y->fname);
-        return cmp ? cmp : y->width != x->width ? y->width - x->width : y->height - x->height;
+        if (cmp) {
+            return cmp;
+        }
+
+        if (y->width != x->width) {
+            return y->width - x->width;
+        }
+
+        return y->height - x->height;
     }
 
     return x->pixbuf ? -1 : y->pixbuf ? 1 : 0;

--- a/plugins/gtkui/coverart.h
+++ b/plugins/gtkui/coverart.h
@@ -38,6 +38,8 @@ get_cover_art_callb (const const char *fname, const char *artist, const char *al
 GdkPixbuf *
 get_cover_art_primary (const const char *fname, const char *artist, const char *album, int width, void (*cover_avail_callback) (void *user_data), void *user_data);
 GdkPixbuf *
+get_cover_art_primary_by_size (const const char *fname, const char *artist, const char *album, int width, int height, void (*cover_avail_callback) (void *user_data), void *user_data);
+GdkPixbuf *
 get_cover_art_thumb (const const char *fname, const char *artist, const char *album, int width, void (*cover_avail_callback) (void *user_data), void *user_data);
 
 void

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -139,9 +139,9 @@ typedef struct {
 typedef struct {
     ddb_gtkui_widget_t base;
     GtkWidget *drawarea;
-    int cover_size;
-    int new_cover_size;
-    guint cover_refresh_timeout_id;
+    int widget_height;
+    int widget_width;
+    guint load_timeout_id;
 } w_coverart_t;
 
 typedef struct {
@@ -765,7 +765,11 @@ w_button_press_event (GtkWidget *widget, GdkEventButton *event, gpointer user_da
 
     if (GTK_IS_CONTAINER (widget)) {
         // hide all children
+#if !GTK_CHECK_VERSION(3,0,0)
         gtk_widget_size_request (widget, &prev_req);
+#else
+        gtk_widget_get_preferred_size (widget, NULL, &prev_req);
+#endif
         gtk_container_foreach (GTK_CONTAINER (widget), hide_widget, NULL);
         gtk_widget_set_size_request (widget, prev_req.width, prev_req.height);
     }
@@ -1863,7 +1867,7 @@ w_tabs_init (ddb_gtkui_widget_t *base) {
             if (w->titles[page]) {
                 gtk_notebook_set_tab_label_text (GTK_NOTEBOOK (w->base.widget), child, w->titles[page]);
 #if GTK_CHECK_VERSION(3,0,0)
-                GtkLabel *label = gtk_notebook_get_tab_label (GTK_NOTEBOOK (w->base.widget), child);
+                GtkLabel *label = GTK_LABEL(gtk_notebook_get_tab_label (GTK_NOTEBOOK (w->base.widget), child));
                 gtk_label_set_ellipsize (GTK_LABEL (label), PANGO_ELLIPSIZE_END);
                 gtk_misc_set_padding (GTK_MISC (label), 0, 0);
 #endif
@@ -2598,116 +2602,107 @@ w_selproperties_create (void) {
 }
 
 ///// cover art display
+static GdkPixbuf *
+get_cover_art(const int width, const int height, void (*callback)(void *), void *user_data) {
+    DB_playItem_t *it = deadbeef->streamer_get_playing_track();
+    if (!it) {
+        return NULL;
+    }
+
+    deadbeef->pl_lock();
+    const char *uri = deadbeef->pl_find_meta(it, ":URI");
+    const char *album = deadbeef->pl_find_meta(it, "album");
+    const char *artist = deadbeef->pl_find_meta(it, "artist");
+    if (!album || !*album) {
+        album = deadbeef->pl_find_meta(it, "title");
+    }
+    GdkPixbuf *pixbuf = get_cover_art_primary_by_size(uri, artist, album, width, height, callback, user_data);
+    deadbeef->pl_unlock();
+    deadbeef->pl_item_unref(it);
+    return pixbuf;
+}
+
 static gboolean
-coverart_redraw_cb (void *user_data) {
+coverart_invalidate_cb (void *user_data) {
     w_coverart_t *w = user_data;
-    w->cover_size = w->new_cover_size;
-    gtk_widget_queue_draw (w->drawarea);
+    gtk_widget_queue_draw(w->drawarea);
     return FALSE;
 }
 
 void
-coverart_avail_callback (void *user_data) {
-    g_idle_add (coverart_redraw_cb, user_data);
+coverart_invalidate (void *user_data) {
+    g_idle_add(coverart_invalidate_cb, user_data);
 }
 
 static gboolean
-coverart_redraw_single_cb (void *user_data) {
+coverart_load (void *user_data) {
     w_coverart_t *w = user_data;
-    gtk_widget_queue_draw (w->drawarea);
+    w->load_timeout_id = 0;
+    GdkPixbuf *pixbuf = get_cover_art(w->widget_width, w->widget_height, coverart_invalidate, user_data);
+    if (pixbuf) {
+        coverart_invalidate(user_data);
+        g_object_unref(pixbuf);
+    }
     return FALSE;
 }
 
 static void
-coverart_avail_callback_single (gpointer user_data) {
-    g_idle_add (coverart_redraw_single_cb, user_data);
+coverart_draw_cairo (GdkPixbuf *pixbuf, GtkAllocation *a, cairo_t *cr, const int filter) {
+    const int pw = gdk_pixbuf_get_width(pixbuf);
+    const int ph = gdk_pixbuf_get_height(pixbuf);
+    cairo_rectangle(cr, 0, 0, a->width, a->height);
+    if (pw > a->width || ph > a->height || pw < a->width && ph < a->height) {
+        const double scale = min(a->width/(double)pw, a->height/(double)ph);
+        cairo_translate(cr, (a->width - a->width*scale)/2., (a->height - a->height*scale)/2.);
+        cairo_scale(cr, scale, scale);
+        cairo_pattern_set_filter(cairo_get_source(cr), filter);
+    }
+    gdk_cairo_set_source_pixbuf(cr, pixbuf, (a->width - pw)/2., (a->height - ph)/2.);
+    cairo_fill(cr);
 }
 
-static gboolean
-deferred_cover_load_cb (void *ctx) {
-    w_coverart_t *w = ctx;
-    w->cover_refresh_timeout_id = 0;
-    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
-    if (!it) {
-        return FALSE;
-    }
-    GtkAllocation a;
-    gtk_widget_get_allocation (GTK_WIDGET (w->drawarea), &a);
-    deadbeef->pl_lock ();
-    const char *album = deadbeef->pl_find_meta (it, "album");
-    const char *artist = deadbeef->pl_find_meta (it, "artist");
-    if (!album || !*album) {
-        album = deadbeef->pl_find_meta (it, "title");
-    }
-    GdkPixbuf *pixbuf = get_cover_art_primary (deadbeef->pl_find_meta (((DB_playItem_t *)it), ":URI"), artist, album, w->new_cover_size, NULL, NULL);
-    deadbeef->pl_unlock ();
-    deadbeef->pl_item_unref (it);
-    queue_cover_callback (coverart_avail_callback, w);
+static void
+coverart_draw_anything (GtkAllocation *a, cairo_t *cr) {
+    GdkPixbuf *pixbuf = get_cover_art(-1, -1, NULL, NULL);
     if (pixbuf) {
-        g_object_unref (pixbuf);
+        coverart_draw_cairo(pixbuf, a, cr, CAIRO_FILTER_FAST);
+        g_object_unref(pixbuf);
     }
+}
 
-    return FALSE;
+static void
+coverart_draw_exact (GtkAllocation *a, cairo_t *cr, void *user_data) {
+    GdkPixbuf *pixbuf = get_cover_art(a->width, a->height, coverart_invalidate, user_data);
+    if (pixbuf) {
+        coverart_draw_cairo(pixbuf, a, cr, CAIRO_FILTER_BEST);
+        g_object_unref(pixbuf);
+    }
+    else {
+        coverart_draw_anything(a, cr);
+    }
 }
 
 static gboolean
 coverart_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data) {
     GtkAllocation a;
-    gtk_widget_get_allocation (widget, &a);
-
-    int real_size = min(a.width, a.height);
-    if (real_size < 8) {
-        return TRUE;
-    }
-
-    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
-    if (!it) {
+    gtk_widget_get_allocation(widget, &a);
+    if (a.width < 8 || a.height < 8) {
         return TRUE;
     }
 
     w_coverart_t *w = user_data;
-    if (w->new_cover_size != real_size) {
-        w->new_cover_size = real_size;
-        if (w->cover_refresh_timeout_id) {
-            g_source_remove (w->cover_refresh_timeout_id);
-            w->cover_refresh_timeout_id = 0;
-        }
-        if (w->cover_size == -1) {
-            w->cover_size = real_size;
-            g_idle_add (deferred_cover_load_cb, w);
-        }
-        else {
-            if (!w->cover_refresh_timeout_id) {
-                w->cover_refresh_timeout_id = g_timeout_add (1000, deferred_cover_load_cb, w);
-            }
-        }
+    if (w->widget_height == a.height && w->widget_width == a.width) {
+        coverart_draw_exact(&a, cr, user_data);
     }
-
-    deadbeef->pl_lock ();
-    const char *album = deadbeef->pl_find_meta (it, "album");
-    const char *artist = deadbeef->pl_find_meta (it, "artist");
-    if (!album || !*album) {
-        album = deadbeef->pl_find_meta (it, "title");
+    else {
+        coverart_draw_anything(&a, cr);
+        w->widget_height = a.height;
+        w->widget_width = a.width;
+        if (w->load_timeout_id) {
+            g_source_remove(w->load_timeout_id);
+        }
+        w->load_timeout_id = g_timeout_add(1000, coverart_load, user_data);
     }
-    const int size = w->cover_size == real_size ? w->cover_size : -1;
-    GdkPixbuf *pixbuf = get_cover_art_primary(deadbeef->pl_find_meta(it, ":URI"), artist, album, size, coverart_avail_callback_single, user_data);
-    deadbeef->pl_unlock ();
-
-    if (pixbuf) {
-        const float pw = gdk_pixbuf_get_width(pixbuf);
-        const float ph = gdk_pixbuf_get_height(pixbuf);
-        const float scale = min(a.width/pw, a.height/ph);
-        const float x = max((a.width - scale*pw)/2, 0);
-        const float y = max((a.height - scale*ph)/2, 0);
-        cairo_rectangle(cr, x, y, a.width, a.height);
-        cairo_scale(cr, scale, scale);
-        gdk_cairo_set_source_pixbuf(cr, pixbuf, x/scale, y/scale);
-        cairo_pattern_set_filter(cairo_get_source(cr), gtkui_is_default_pixbuf(pixbuf) ? CAIRO_FILTER_BEST : CAIRO_FILTER_FAST);
-        cairo_fill(cr);
-        g_object_unref(pixbuf);
-    }
-
-    deadbeef->pl_item_unref (it);
 
     return TRUE;
 }
@@ -2722,20 +2717,19 @@ coverart_expose_event (GtkWidget *widget, GdkEventExpose *event, gpointer user_d
 
 static int
 coverart_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
-    w_coverart_t *ca = (w_coverart_t *)w;
     switch (id) {
     case DB_EV_PLAYLIST_REFRESH:
-        g_idle_add (coverart_redraw_cb, w);
+        coverart_invalidate(w);
         break;
     case DB_EV_SONGSTARTED:
-        g_idle_add (coverart_redraw_cb, w);
+        coverart_invalidate(w);
         break;
     case DB_EV_TRACKINFOCHANGED:
         {
             ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
             DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
             if (it == ev->track) {
-                g_idle_add (coverart_redraw_cb, w);
+                coverart_invalidate(w);
             }
             if (it) {
                 deadbeef->pl_item_unref (it);
@@ -2754,8 +2748,8 @@ w_coverart_create (void) {
     w->base.widget = gtk_event_box_new ();
     w->base.message = coverart_message;
     w->drawarea = gtk_drawing_area_new ();
-    w->cover_size = -1;
-    w->new_cover_size = -1;
+    w->widget_height = -1;
+    w->widget_width = -1;
     gtk_widget_show (w->drawarea);
     gtk_container_add (GTK_CONTAINER (w->base.widget), w->drawarea);
 #if !GTK_CHECK_VERSION(3,0,0)


### PR DESCRIPTION
See bug #1200.  This pull request fixes the large widget scaling.  It allows requesting cover art by both height and width, to avoid the problem of not knowing what scaling to use without knowing the image dimensions and not knowing the image dimensions until the file has been loaded.  There is no change to the external API, although maybe the new call could be exposed.