### PR TITLE
emit compile warning

### DIFF
--- a/plugins/adplug/Makefile.am
+++ b/plugins/adplug/Makefile.am
@@ -7,7 +7,7 @@ pkglib_LTLIBRARIES = adplug.la
 AM_CFLAGS = $(CFLAGS) -std=c99 -I$(adplugpath)/adplug -I$(adplugpath)/libbinio -fPIC
 adplug_la_LDFLAGS = -module -avoid-version $(NOCPPLIB) -lm
 
-AM_CPPFLAGS = $(CXXFLAGS) -Dstricmp=strcasecmp -DVERSION=\"2.1\" -I$(adplugpath)/adplug -I$(adplugpath)/libbinio -fno-exceptions -fno-rtti -fno-unwind-tables
+AM_CXXFLAGS = $(CXXFLAGS) -Dstricmp=strcasecmp -DVERSION=\"2.1\" -I$(adplugpath)/adplug -I$(adplugpath)/libbinio -fno-exceptions -fno-rtti -fno-unwind-tables
 
 adplug_la_SOURCES = plugin.c\
                    adplug-db.cpp\

--- a/plugins/gme/Makefile.am
+++ b/plugins/gme/Makefile.am
@@ -325,5 +325,5 @@ gme_la_LDFLAGS = -module -avoid-version $(NOCPPLIB)
 gme_la_LIBADD = $(ZLIB_LIBS)
 
 AM_CFLAGS = $(CFLAGS) $(ZLIB_CFLAGS) -I$(gmepath) -std=c99 -DGME_VERSION_055
-AM_CPPFLAGS = $(CXXFLAGS) $(ZLIB_CFLAGS) -I$(gmepath) -I$(gmepath)/gme -DGME_VERSION_055 -fno-exceptions -fno-rtti -fno-unwind-tables
+AM_CXXFLAGS = $(CXXFLAGS) $(ZLIB_CFLAGS) -I$(gmepath) -I$(gmepath)/gme -DGME_VERSION_055 -fno-exceptions -fno-rtti -fno-unwind-tables
 endif

--- a/plugins/sid/Makefile.am
+++ b/plugins/sid/Makefile.am
@@ -106,6 +106,6 @@ sidplay-libs/libsidplay/src/poweron.bin
 sid_la_LDFLAGS = -module -avoid-version $(NOCPPLIB)
 
 AM_CFLAGS = $(CFLAGS) -std=c99 -I$(sidpath)/libsidplay/include -I$(sidpath)/builders/resid-builder/include -fPIC
-AM_CPPFLAGS = $(CXXFLAGS) -DHAVE_UNIX -I$(sidpath) -I$(sidpath)/unix -I$(sidpath)/libsidplay -I$(sidpath)/libsidplay/include -I$(sidpath)/libsidplay/include/sidplay -I$(sidpath)/libsidutils/include/sidplay/utils -I$(sidpath)/builders/resid-builder/include/sidplay/builders -I$(sidpath)/builders/resid-builder/include -DHAVE_STRCASECMP -DHAVE_STRNCASECMP -fno-exceptions -fno-rtti -fno-unwind-tables
+AM_CXXFLAGS = $(CXXFLAGS) -DHAVE_UNIX -I$(sidpath) -I$(sidpath)/unix -I$(sidpath)/libsidplay -I$(sidpath)/libsidplay/include -I$(sidpath)/libsidplay/include/sidplay -I$(sidpath)/libsidutils/include/sidplay/utils -I$(sidpath)/builders/resid-builder/include/sidplay/builders -I$(sidpath)/builders/resid-builder/include -DHAVE_STRCASECMP -DHAVE_STRNCASECMP -fno-exceptions -fno-rtti -fno-unwind-tables
 
 endif

--- a/plugins/supereq/Makefile.am
+++ b/plugins/supereq/Makefile.am
@@ -4,7 +4,7 @@ pkglib_LTLIBRARIES = supereq.la
 supereq_la_SOURCES = supereq.c Equ.cpp Equ.h Fftsg_fl.c paramlist.hpp
 
 AM_CFLAGS = $(CFLAGS) -std=c99 -DUSE_OOURA
-AM_CPPFLAGS = $(CXXFLAGS) -fno-exceptions -fno-rtti -fno-unwind-tables -DUSE_OOURA
+AM_CXXFLAGS = $(CXXFLAGS) -fno-exceptions -fno-rtti -fno-unwind-tables -DUSE_OOURA
 
 supereq_la_LDFLAGS = -module -avoid-version $(NOCPPLIB)
 


### PR DESCRIPTION
"cc1: warning: command line option ‘-fno-rtti’ is valid for C++/ObjC++
but not for C"