### PR TITLE
Playlist artwork and rendering changes

### DIFF
--- a/plugins/gtkui/coverart.c
+++ b/plugins/gtkui/coverart.c
@@ -61,7 +61,7 @@ static GdkPixbuf *pixbuf_default;
 static size_t thrash_count;
 
 typedef struct cover_callback_s {
-    cover_avail_callback cb;
+    cover_avail_callback_t cb;
     void *ud;
     struct cover_callback_s *next;
 } cover_callback_t;
@@ -87,7 +87,7 @@ typedef struct {
     char *cache_path;
     int width;
     int height;
-    cover_avail_callback callback;
+    cover_avail_callback_t callback;
     void *user_data;
 } cover_avail_info_t;
 
@@ -139,7 +139,7 @@ gtkui_is_default_pixbuf (GdkPixbuf *pb) {
 }
 
 static cover_callback_t *
-add_callback(cover_avail_callback cb, void *ud)
+add_callback(cover_avail_callback_t cb, void *ud)
 {
     if (!cb) {
         return NULL;
@@ -171,7 +171,7 @@ process_query_callbacks(cover_callback_t *callback, const int send)
 }
 
 static void
-queue_add (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback cb, void *ud)
+queue_add (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback_t cb, void *ud)
 {
     trace("coverart: queue_add %s @ %ix%i pixels\n", fname, width, height);
     load_query_t *q = malloc(sizeof(load_query_t));
@@ -198,7 +198,7 @@ queue_add (cache_type_t cache_type, char *fname, const int width, const int heig
 }
 
 static void
-queue_add_load (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback cb, void *ud)
+queue_add_load (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback_t cb, void *ud)
 {
     for (load_query_t *q = queue; q; q = q->next) {
         if (q->fname && !strcmp (q->fname, fname) && width == q->width && height == q->height) {
@@ -446,7 +446,7 @@ get_pixbuf (cache_type_t cache_type, const char *fname, const int width, const i
 }
 
 void
-queue_cover_callback (cover_avail_callback callback, void *user_data) {
+queue_cover_callback (cover_avail_callback_t callback, void *user_data) {
     if (artwork_plugin && callback) {
         deadbeef->mutex_lock (mutex);
         queue_add(-1, NULL, -1, -1, callback, user_data);
@@ -512,7 +512,7 @@ best_cached_pixbuf(cache_type_t cache_type, const char *path)
 }
 
 static cover_avail_info_t *
-cover_avail_info(cache_type_t cache_type, char *cache_path, const int width, const int height, cover_avail_callback callback, void *user_data)
+cover_avail_info(cache_type_t cache_type, char *cache_path, const int width, const int height, cover_avail_callback_t callback, void *user_data)
 {
     if (cache_path) {
         cover_avail_info_t *dt = malloc(sizeof(cover_avail_info_t));
@@ -534,7 +534,7 @@ cover_avail_info(cache_type_t cache_type, char *cache_path, const int width, con
 }
 
 static GdkPixbuf *
-get_cover_art_int(cache_type_t cache_type, const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback callback, void *user_data)
+get_cover_art_int(cache_type_t cache_type, const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback_t callback, void *user_data)
 {
     if (!artwork_plugin) {
         return NULL;
@@ -581,31 +581,31 @@ get_cover_art_int(cache_type_t cache_type, const char *fname, const char *artist
 
 // Deprecated
 GdkPixbuf *
-get_cover_art_callb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback callback, void *user_data)
+get_cover_art_callb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t callback, void *user_data)
 {
     return get_cover_art_int(CACHE_TYPE_THUMB, fname, artist, album, width, -1, callback, user_data);
 }
 
 GdkPixbuf *
-get_cover_art_primary (const char *fname, const char *artist, const char *album, int width, cover_avail_callback callback, void *user_data)
+get_cover_art_primary (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t callback, void *user_data)
 {
     return get_cover_art_int(CACHE_TYPE_PRIMARY, fname, artist, album, width, -1, callback, user_data);
 }
 
 GdkPixbuf *
-get_cover_art_primary_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback callback, void *user_data)
+get_cover_art_primary_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback_t callback, void *user_data)
 {
     return get_cover_art_int(CACHE_TYPE_PRIMARY, fname, artist, album, width, height, callback, user_data);
 }
 
 GdkPixbuf *
-get_cover_art_thumb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback callback, void *user_data)
+get_cover_art_thumb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t callback, void *user_data)
 {
     return get_cover_art_int(CACHE_TYPE_THUMB, fname, artist, album, width, -1, callback, user_data);
 }
 
 GdkPixbuf *
-get_cover_art_thumb_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback callback, void *user_data)
+get_cover_art_thumb_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback_t callback, void *user_data)
 {
     return get_cover_art_int(CACHE_TYPE_THUMB, fname, artist, album, width, height, callback, user_data);
 }

--- a/plugins/gtkui/coverart.c
+++ b/plugins/gtkui/coverart.c
@@ -307,7 +307,7 @@ adjust_cache(struct timeval *oldest)
     thrash_count = timeval_older(&now, oldest) ? thrash_count+1 : 0;
 
     /* Grab more space more quickly at small cache sizes */
-    if (1<<thrash_count > thumb_cache_size) {
+    if (thrash_count*2 >= thumb_cache_size) {
         cached_pixbuf_t *new_thumb_cache = realloc(thumb_cache, sizeof(cached_pixbuf_t) * thumb_cache_size * 2);
         if (new_thumb_cache) {
             memset(&new_thumb_cache[thumb_cache_size], '\0', sizeof(cached_pixbuf_t) * thumb_cache_size);

--- a/plugins/gtkui/coverart.c
+++ b/plugins/gtkui/coverart.c
@@ -158,7 +158,7 @@ add_callback(cover_avail_callback_t cb, void *ud)
 }
 
 static void
-process_query_callbacks(cover_callback_t *callback, const int send)
+process_query_callbacks(cover_callback_t *callback, int send)
 {
     if (callback) {
         if (send) {
@@ -171,7 +171,7 @@ process_query_callbacks(cover_callback_t *callback, const int send)
 }
 
 static void
-queue_add (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback_t cb, void *ud)
+queue_add (cache_type_t cache_type, char *fname, int width, int height, cover_avail_callback_t cb, void *ud)
 {
     trace("coverart: queue_add %s @ %ix%i pixels\n", fname, width, height);
     load_query_t *q = malloc(sizeof(load_query_t));
@@ -198,7 +198,7 @@ queue_add (cache_type_t cache_type, char *fname, const int width, const int heig
 }
 
 static void
-queue_add_load (cache_type_t cache_type, char *fname, const int width, const int height, cover_avail_callback_t cb, void *ud)
+queue_add_load (cache_type_t cache_type, char *fname, int width, int height, cover_avail_callback_t cb, void *ud)
 {
     for (load_query_t *q = queue; q; q = q->next) {
         if (q->fname && !strcmp (q->fname, fname) && width == q->width && height == q->height) {
@@ -322,7 +322,7 @@ adjust_cache(struct timeval *oldest)
 }
 
 static void
-cache_add(cache_type_t cache_type, GdkPixbuf *pixbuf, char *fname, const time_t file_time, const int width, const int height)
+cache_add(cache_type_t cache_type, GdkPixbuf *pixbuf, char *fname, const time_t file_time, int width, int height)
 {
     cached_pixbuf_t *cache = cache_location(cache_type);
     size_t cache_size = cache_elements(cache_type);
@@ -420,7 +420,7 @@ loading_thread (void *none) {
 }
 
 static GdkPixbuf *
-get_pixbuf (cache_type_t cache_type, const char *fname, const int width, const int height) {
+get_pixbuf (cache_type_t cache_type, const char *fname, int width, int height) {
     /* Look in the pixbuf cache */
     cached_pixbuf_t *cache = cache_location(cache_type);
     const size_t cache_size = cache_elements(cache_type);
@@ -512,7 +512,7 @@ best_cached_pixbuf(cache_type_t cache_type, const char *path)
 }
 
 static cover_avail_info_t *
-cover_avail_info(cache_type_t cache_type, char *cache_path, const int width, const int height, cover_avail_callback_t callback, void *user_data)
+cover_avail_info(cache_type_t cache_type, char *cache_path, int width, int height, cover_avail_callback_t callback, void *user_data)
 {
     if (cache_path) {
         cover_avail_info_t *dt = malloc(sizeof(cover_avail_info_t));

--- a/plugins/gtkui/coverart.h
+++ b/plugins/gtkui/coverart.h
@@ -33,17 +33,17 @@
 // if the image is not available immediately -- callback will be called later
 //
 // if  artwork plugin is not available -- NULL will be returned and no callbacks made
-typedef void (*cover_avail_callback) (void *user_data);
+typedef void (*cover_avail_callback_t) (void *user_data);
 GdkPixbuf *
-get_cover_art_callb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
+get_cover_art_callb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t, void *user_data);
 GdkPixbuf *
-get_cover_art_primary (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
+get_cover_art_primary (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t, void *user_data);
 GdkPixbuf *
-get_cover_art_primary_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback, void *user_data);
+get_cover_art_primary_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback_t, void *user_data);
 GdkPixbuf *
-get_cover_art_thumb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
+get_cover_art_thumb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback_t, void *user_data);
 GdkPixbuf *
-get_cover_art_thumb_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback, void *user_data);
+get_cover_art_thumb_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback_t, void *user_data);
 
 void
 coverart_reset_queue (void);

--- a/plugins/gtkui/coverart.h
+++ b/plugins/gtkui/coverart.h
@@ -27,20 +27,23 @@
 #include <gtk/gtk.h>
 #include "../../deadbeef.h"
 
-// this function puts request for cover art into queue, or returns default image
+// these functions put requests for cover art into queue, or return default image
 // of specific size
 //
 // if the image is not available immediately -- callback will be called later
 //
 // if  artwork plugin is not available -- NULL will be returned and no callbacks made
+typedef void (*cover_avail_callback) (void *user_data);
 GdkPixbuf *
-get_cover_art_callb (const const char *fname, const char *artist, const char *album, int width, void (*cover_avail_callback) (void *user_data), void *user_data);
+get_cover_art_callb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
 GdkPixbuf *
-get_cover_art_primary (const const char *fname, const char *artist, const char *album, int width, void (*cover_avail_callback) (void *user_data), void *user_data);
+get_cover_art_primary (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
 GdkPixbuf *
-get_cover_art_primary_by_size (const const char *fname, const char *artist, const char *album, int width, int height, void (*cover_avail_callback) (void *user_data), void *user_data);
+get_cover_art_primary_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback, void *user_data);
 GdkPixbuf *
-get_cover_art_thumb (const const char *fname, const char *artist, const char *album, int width, void (*cover_avail_callback) (void *user_data), void *user_data);
+get_cover_art_thumb (const char *fname, const char *artist, const char *album, int width, cover_avail_callback, void *user_data);
+GdkPixbuf *
+get_cover_art_thumb_by_size (const char *fname, const char *artist, const char *album, int width, int height, cover_avail_callback, void *user_data);
 
 void
 coverart_reset_queue (void);

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1466,6 +1466,20 @@ ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGro
     DdbListviewColumn *c;
     for (c = ps->columns; c; x += c->width, c = c->next) {
         if (ps->binding->is_album_art_column(c->user_data) && x + c->width > x1 && x < x2) {
+            if (gtkui_override_listview_colors()) {
+                GdkColor clr;
+                gtkui_get_listview_even_row_color(&clr);
+                cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
+                cairo_rectangle(cr, x, y, c->width, grp->height);
+                cairo_fill(cr);
+            }
+            else {
+#if GTK_CHECK_VERSION(3,0,0)
+                render_row_background(ps, GTK_STATE_NORMAL, TRUE, cr, x, y, c->width, grp->height);
+#else
+                gtk_paint_flat_box(gtk_widget_get_style(ps->theme_treeview), gtk_widget_get_window(ps->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, ps->theme_treeview, "cell_even_ruled", x, y, c->width, grp->height);
+#endif
+            }
             ps->binding->draw_album_art(ps, cr, ps->grouptitle_height > 0 ? grp->head : NULL, c->user_data, grp->pinned, grp_next_y, x, y, c->width, grp->height);
         }
     }
@@ -2374,11 +2388,11 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, const int x1, const in
 #if GTK_CHECK_VERSION(3,0,0)
                     GtkStyleContext *context = gtk_widget_get_style_context(ps->theme_treeview);
                     gtk_style_context_add_class(context, GTK_STYLE_CLASS_SEPARATOR);
-                    gtk_render_frame(context, cr, xx-2, 2, 2, h-4);
+                    gtk_render_line(context, cr, xx-3, 2, xx-3, h-4);
                     gtk_style_context_remove_class(context, GTK_STYLE_CLASS_SEPARATOR);
 //                    gtk_paint_vline (gtk_widget_get_style (ps->header), cr, GTK_STATE_NORMAL, ps->header, NULL, 2, h-4, xx - 3);
 #else
-                    gtk_paint_vline (ps->header->style, ps->header->window, GTK_STATE_NORMAL, NULL, ps->header, NULL, 2, h-4, xx-2);
+                    gtk_paint_vline (ps->header->style, ps->header->window, GTK_STATE_NORMAL, NULL, ps->header, NULL, 2, h-4, xx-3);
 #endif
                 }
             }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -57,6 +57,9 @@
 //#define REF(it) {if (it) ps->binding->ref (it);}
 #define UNREF(it) {if (it) ps->binding->unref(it);}
 
+extern GtkWidget *theme_treeview;
+extern GtkWidget *theme_button;
+
 G_DEFINE_TYPE (DdbListview, ddb_listview, GTK_TYPE_TABLE);
 
 struct _DdbListviewColumn {
@@ -373,15 +376,6 @@ ddb_listview_init(DdbListview *listview)
     vbox = gtk_vbox_new (FALSE, 0);
     gtk_widget_show (vbox);
     gtk_box_pack_start (GTK_BOX (hbox), vbox, TRUE, TRUE, 0);
-
-    listview->theme_treeview = gtk_tree_view_new();
-    gtk_widget_show(listview->theme_treeview);
-    gtk_widget_set_can_focus(listview->theme_treeview, FALSE);
-    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(listview->theme_treeview), TRUE);
-    gtk_box_pack_start(GTK_BOX(vbox), listview->theme_treeview, FALSE, FALSE, 0);
-    GtkTreeViewColumn *column = gtk_tree_view_column_new();
-    gtk_tree_view_append_column(GTK_TREE_VIEW(listview->theme_treeview), column);
-    gtk_tree_view_column_set_widget(column, gtk_label_new(""));
 
     GtkWidget *sepbox = gtk_vbox_new (FALSE, 0);
     gtk_widget_show (sepbox);
@@ -734,15 +728,19 @@ ddb_listview_list_pickpoint_y (DdbListview *listview, int y, DdbListviewGroup **
 static void
 render_column_button (DdbListview *listview, GtkStateFlags state, cairo_t *cr, int x, int y, int w, int h)
 {
-    GtkStyleContext *context = gtk_widget_get_style_context(listview->theme_button);
+    GtkStyleContext *context = gtk_widget_get_style_context(theme_button);
+    gtk_style_context_save(context);
+    gtk_style_context_add_class(context, GTK_STYLE_CLASS_BUTTON);
     gtk_style_context_set_state(context, state);
+    gtk_style_context_add_region(context, GTK_STYLE_REGION_COLUMN_HEADER, 0);
     gtk_render_background(context, cr, x, y, w, h);
+    gtk_style_context_restore(context);
 }
 
 static void
 render_row_background (DdbListview *listview, GtkStateFlags state, int even, cairo_t *cr, int x, int y, int w, int h)
 {
-    GtkStyleContext *context = gtk_widget_get_style_context(listview->theme_treeview);
+    GtkStyleContext *context = gtk_widget_get_style_context(theme_treeview);
     gtk_style_context_save(context);
     gtk_style_context_add_class(context, GTK_STYLE_CLASS_CELL);
     gtk_style_context_set_state(context, state);
@@ -764,7 +762,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
     }
 #if !GTK_CHECK_VERSION(3,0,0)
 // FIXME?
-    if (gtk_widget_get_style (listview->theme_treeview)->depth == -1) {
+    if (gtk_widget_get_style (theme_treeview)->depth == -1) {
         return; // drawing was called too early
     }
 #endif
@@ -832,9 +830,9 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
             if (!gtkui_override_listview_colors()) {
 #if GTK_CHECK_VERSION(3,0,0)
                 render_row_background(listview, GTK_STATE_FLAG_NORMAL, TRUE, cr, x, yy, w, filler);
-//                gtk_paint_flat_box (gtk_widget_get_style (listview->theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, listview->theme_treeview, "cell_even_ruled", x, grp_y + grp_height, w, filler);
+//                gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, theme_treeview, "cell_even_ruled", x, grp_y + grp_height, w, filler);
 #else
-                gtk_paint_flat_box(gtk_widget_get_style(listview->theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, listview->theme_treeview, "cell_even_ruled", x, yy, w, filler);
+                gtk_paint_flat_box(gtk_widget_get_style(theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, theme_treeview, "cell_even_ruled", x, yy, w, filler);
 #endif
             }
             else {
@@ -874,9 +872,9 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
         if (!gtkui_override_listview_colors()) {
 #if GTK_CHECK_VERSION(3,0,0)
             render_row_background(listview, GTK_STATE_FLAG_NORMAL, TRUE, cr, x, grp_y, w, hh);
-//            gtk_paint_flat_box (gtk_widget_get_style (listview->theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, listview->theme_treeview, "cell_even_ruled", x, grp_y, w, hh);
+//            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, theme_treeview, "cell_even_ruled", x, grp_y, w, hh);
 #else
-            gtk_paint_flat_box(gtk_widget_get_style(listview->theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, listview->theme_treeview, "cell_even_ruled", x, grp_y, w, hh);
+            gtk_paint_flat_box(gtk_widget_get_style(theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, theme_treeview, "cell_even_ruled", x, grp_y, w, hh);
 #endif
         }
         else {
@@ -1376,7 +1374,7 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
 
     if (theming) {
 #if !GTK_CHECK_VERSION(3,0,0)
-        if (gtk_widget_get_style (ps->theme_treeview)->depth == -1) {
+        if (gtk_widget_get_style (theme_treeview)->depth == -1) {
             return; // drawing was called too early
         }
 #endif
@@ -1388,9 +1386,9 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
             // draw background for selection -- workaround for New Wave theme (translucency)
 #if GTK_CHECK_VERSION(3,0,0)
             render_row_background(ps, GTK_STATE_FLAG_NORMAL, even, cr, x, y, w, h);
-//            gtk_paint_flat_box (gtk_widget_get_style (ps->theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, ps->theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
+//            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
 #else
-            gtk_paint_flat_box (gtk_widget_get_style (ps->theme_treeview), ps->list->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, ps->theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
+            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), ps->list->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
 #endif
         }
         else {
@@ -1406,11 +1404,11 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
         if (theming) {
 #if GTK_CHECK_VERSION(3,0,0)
             render_row_background(ps, GTK_STATE_FLAG_SELECTED, even, cr, x, y, w, h);
-//            gtk_paint_flat_box (gtk_widget_get_style (ps->theme_treeview), cr, GTK_STATE_SELECTED, GTK_SHADOW_NONE, ps->theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x-1, y-1, w+1, h+1);
+//            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), cr, GTK_STATE_SELECTED, GTK_SHADOW_NONE, theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x-1, y-1, w+1, h+1);
 #else
-            gtk_paint_flat_box (gtk_widget_get_style (ps->theme_treeview), ps->list->window, GTK_STATE_SELECTED, GTK_SHADOW_NONE, NULL, ps->theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
+            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), ps->list->window, GTK_STATE_SELECTED, GTK_SHADOW_NONE, NULL, theme_treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
             //            if (gtk_widget_has_focus (ps->list)) {
-            //                gtk_paint_focus (gtk_widget_get_style (ps->theme_treeview), ps->list->window, GTK_STATE_SELECTED, NULL, ps->theme_treeview, "treeview", x, y, w, h);
+            //                gtk_paint_focus (gtk_widget_get_style (theme_treeview), ps->list->window, GTK_STATE_SELECTED, NULL, theme_treeview, "treeview", x, y, w, h);
             //            }
 #endif
         }
@@ -1441,12 +1439,12 @@ ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListvi
     width = a.width;
     height = a.height;
     if (it && ps->binding->is_selected (it)) {
-        GdkColor *clr = &gtk_widget_get_style (ps->theme_treeview)->fg[GTK_STATE_SELECTED];
+        GdkColor *clr = &gtk_widget_get_style (theme_treeview)->fg[GTK_STATE_SELECTED];
         float rgb[3] = { clr->red/65535., clr->green/65535., clr->blue/65535. };
         draw_set_fg_color (&ps->listctx, rgb);
     }
     else {
-        GdkColor *clr = &gtk_widget_get_style (ps->theme_treeview)->fg[GTK_STATE_NORMAL];
+        GdkColor *clr = &gtk_widget_get_style (theme_treeview)->fg[GTK_STATE_NORMAL];
         float rgb[3] = { clr->red/65535., clr->green/65535., clr->blue/65535. };
         draw_set_fg_color (&ps->listctx, rgb);
     }
@@ -1475,7 +1473,7 @@ ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGro
 #if GTK_CHECK_VERSION(3,0,0)
                 render_row_background(ps, GTK_STATE_NORMAL, TRUE, cr, x, y, c->width, grp->height);
 #else
-                gtk_paint_flat_box(gtk_widget_get_style(ps->theme_treeview), gtk_widget_get_window(ps->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, ps->theme_treeview, "cell_even_ruled", x, y, c->width, grp->height);
+                gtk_paint_flat_box(gtk_widget_get_style(theme_treeview), gtk_widget_get_window(ps->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, theme_treeview, "cell_even_ruled", x, y, c->width, grp->height);
 #endif
             }
             ps->binding->draw_album_art(ps, cr, ps->grouptitle_height > 0 ? grp->head : NULL, c->user_data, grp->pinned, grp_next_y, x, y, c->width, grp->height);
@@ -2318,7 +2316,7 @@ draw_header_fg(DdbListview *ps, cairo_t *cr, DdbListviewColumn *c, GdkColor *clr
         text_width -= arrow_sz;
 #if GTK_CHECK_VERSION(3,0,0)
 //                gtk_paint_arrow (gtk_widget_get_style (ps->header), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, ps->header, NULL, dir, TRUE, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz, arrow_sz);
-        gtk_render_arrow(gtk_widget_get_style_context(ps->theme_treeview), cr, c->sort_order*G_PI, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz);
+        gtk_render_arrow(gtk_widget_get_style_context(theme_treeview), cr, c->sort_order*G_PI, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz);
 #else
         int dir = c->sort_order == 1 ? GTK_ARROW_DOWN : GTK_ARROW_UP;
         gtk_paint_arrow(ps->header->style, ps->header->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, ps->header, NULL, dir, TRUE, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz, arrow_sz);
@@ -2350,10 +2348,10 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
         draw_cairo_line(cr, &clr, 0, h, a.width, h);
 #else
 #if GTK_CHECK_VERSION(3,0,0)
-//       gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_NORMAL, GTK_SHADOW_OUT, ps->header, detail, -10, -10, a.width+20, a.height+20);
+//       gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_NORMAL, GTK_SHADOW_OUT, ps->header, detail, -10, -10, a.width+20, a.height+20);
         render_column_button(ps, GTK_STATE_FLAG_NORMAL, cr, -2, -2, a.width+4, h+4);
 #else
-        gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_NORMAL, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", -2, -2, a.width+4, h+4);
+        gtk_paint_box(gtk_widget_get_style(theme_button), gtk_widget_get_window(ps->header), GTK_STATE_NORMAL, GTK_SHADOW_OUT, NULL, theme_button, "button", -2, -2, a.width+4, h+4);
 #endif
         draw_cairo_line(cr, &gtk_widget_get_style(ps->header)->mid[GTK_STATE_NORMAL], 0, h, a.width, h);
     }
@@ -2372,7 +2370,7 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
                 gtkui_get_listview_column_text_color(&gdkfg);
             }
             else {
-                gdkfg = gtk_widget_get_style(ps->theme_button)->fg[GTK_STATE_NORMAL];
+                gdkfg = gtk_widget_get_style(theme_button)->fg[GTK_STATE_NORMAL];
             }
             draw_header_fg(ps, cr, c, &gdkfg, x, xx, h);
 
@@ -2387,7 +2385,7 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
                 }
                 else {
 #if GTK_CHECK_VERSION(3,0,0)
-                    GtkStyleContext *context = gtk_widget_get_style_context(ps->theme_treeview);
+                    GtkStyleContext *context = gtk_widget_get_style_context(theme_treeview);
                     gtk_style_context_add_class(context, GTK_STYLE_CLASS_SEPARATOR);
                     gtk_render_line(context, cr, xx-3, 2, xx-3, h-4);
                     gtk_style_context_remove_class(context, GTK_STYLE_CLASS_SEPARATOR);
@@ -2416,10 +2414,16 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
         int w = c->width + 2;
         if (xx < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-            render_column_button(ps, GTK_STATE_FLAG_ACTIVE, cr, xx, 0, w, h);
-//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, ps->header, "button", xx, 0, w, h);
+            GtkStyleContext *context = gtk_widget_get_style_context(theme_button);
+            gtk_style_context_save(context);
+            gtk_style_context_add_class(context, GTK_STYLE_CLASS_BUTTON);
+            gtk_style_context_set_state(context, GTK_STATE_FLAG_ACTIVE);
+            gtk_style_context_add_region(context, GTK_STYLE_REGION_COLUMN_HEADER, 0);
+            gtk_render_background(context, cr, xx, 0, w, h);
+            gtk_style_context_restore(context);
+//            gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, ps->header, "button", xx, 0, w, h);
 #else
-            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, NULL, ps->theme_button, "button", xx, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(theme_button), gtk_widget_get_window(ps->header), GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, NULL, theme_button, "button", xx, 0, w, h);
 #endif
         }
 
@@ -2427,10 +2431,14 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
         xx = ps->col_movepos - ps->hscrollpos - 2;
         if (w > 0 && xx < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-            render_column_button(ps, GTK_STATE_FLAG_SELECTED, cr, xx, 0, w, h);
-//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, ps->header, "button", xx, 0, w, h);
+            GtkStyleContext *context = gtk_widget_get_style_context(theme_button);
+            gtk_style_context_save(context);
+            gtk_style_context_set_state(context, GTK_STATE_FLAG_SELECTED);
+            gtk_render_background(context, cr, xx, 0, w, h);
+            gtk_style_context_restore(context);
+//            gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, ps->header, "button", xx, 0, w, h);
 #else
-            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_SELECTED, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", xx, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(theme_button), gtk_widget_get_window(ps->header), GTK_STATE_SELECTED, GTK_SHADOW_OUT, NULL, theme_button, "button", xx, 0, w, h);
 #endif
 
             GdkColor gdkfg;
@@ -2438,7 +2446,7 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
                 gtkui_get_listview_selected_text_color(&gdkfg);
             }
             else {
-                gdkfg = gtk_widget_get_style(ps->theme_button)->fg[GTK_STATE_SELECTED];
+                gdkfg = gtk_widget_get_style(theme_button)->fg[GTK_STATE_SELECTED];
             }
             draw_header_fg(ps, cr, c, &gdkfg, xx, xx+w, h);
         }
@@ -2607,14 +2615,6 @@ ddb_listview_header_realize                      (GtkWidget       *widget,
     DdbListview *listview = DDB_LISTVIEW (g_object_get_data (G_OBJECT (widget), "owner"));
     listview->cursor_sz = gdk_cursor_new (GDK_SB_H_DOUBLE_ARROW);
     listview->cursor_drag = gdk_cursor_new (GDK_FLEUR);
-    listview->theme_button = gtk_tree_view_column_get_widget(gtk_tree_view_get_column(GTK_TREE_VIEW(listview->theme_treeview), 0));
-    while (!GTK_IS_BUTTON(listview->theme_button)) {
-        listview->theme_button = gtk_widget_get_parent(listview->theme_button);
-    }
-#if GTK_CHECK_VERSION(3,0,0)
-    gtk_style_context_add_region(gtk_widget_get_style_context(listview->theme_button), GTK_STYLE_REGION_COLUMN_HEADER, 0);
-#endif
-    gtk_widget_hide(listview->theme_treeview);
 }
 
 gboolean

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -806,7 +806,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
 
         DdbListviewIter it = grp->head;
         listview->binding->ref(it);
-        for (int i = 0, yy = grp_y + listview->grouptitle_height; it && i < grp->num_items && yy < y + h; i++, yy += row_height) {
+        for (int i = 0, yy = grp_y + title_height; it && i < grp->num_items && yy < y + h; i++, yy += row_height) {
             if (yy + row_height >= y) {
 // GTK does this already, plus we are going to draw over every inch of it
 //                GtkStyle *st = gtk_widget_get_style (listview->list);
@@ -850,18 +850,14 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int 
         const int grp_next_y = grp_y + grp_height_total;
         ddb_listview_list_render_album_art(listview, cr, grp, grp_next_y, -scrollx, grp_y + title_height, x, x + w);
 
-        if (grp->pinned == 1 && gtkui_groups_pinned && y <= 0) {
+        if (grp->pinned == 1 && gtkui_groups_pinned && y <= title_height) {
             // draw pinned group title
-            int pushback = 0;
-            if (grp_next_y <= title_height) {
-                pushback = title_height - grp_next_y;
-            }
-            ddb_listview_list_render_row_background(listview, cr, NULL, 1, 0, -scrollx, y - pushback, total_width, title_height);
+            ddb_listview_list_render_row_background(listview, cr, NULL, 1, 0, -scrollx, 0, total_width, min(title_height, grp_next_y));
             if (listview->binding->draw_group_title && title_height > 0) {
-                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, -scrollx, y - pushback, total_width, title_height);
+                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, -scrollx, min(0, grp_next_y-title_height), total_width, title_height);
             }
         }
-        else if (grp_y + title_height >= y && grp_y < y + h) {
+        else if (y <= grp_y + title_height) {
             // draw normal group title
             ddb_listview_list_render_row_background(listview, cr, NULL, 1, 0, -scrollx, grp_y, total_width, title_height);
             if (listview->binding->draw_group_title && title_height > 0) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -2327,7 +2327,7 @@ draw_header_fg(DdbListview *ps, cairo_t *cr, DdbListviewColumn *c, GdkColor *clr
 
     float fg[3] = {clr->red/65535., clr->green/65535., clr->blue/65535.};
     draw_set_fg_color(&ps->hdrctx, fg);
-    draw_text_custom(&ps->hdrctx, x+2, 3, text_width, 0, DDB_COLUMN_FONT, 0, 0, c->title);
+    draw_text_custom(&ps->hdrctx, x+5, 3, text_width, 0, DDB_COLUMN_FONT, 0, 0, c->title);
 }
 
 void
@@ -2412,24 +2412,25 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
         }
 
         // Mark the position where the dragged column used to be with an indented/active/dark position
-        int w = c->width;
-        if (x < x2) {
+        int xx = x - 2; // Where the divider line is
+        int w = c->width + 2;
+        if (xx < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-            render_column_button(ps, GTK_STATE_FLAG_ACTIVE, cr, x-3, 0, w, h);
-//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, ps->header, "button", x, 0, w, h);
+            render_column_button(ps, GTK_STATE_FLAG_ACTIVE, cr, xx, 0, w, h);
+//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, ps->header, "button", xx, 0, w, h);
 #else
-            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, NULL, ps->theme_button, "button", x-3, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, NULL, ps->theme_button, "button", xx, 0, w, h);
 #endif
         }
 
         // Draw a highlighted/selected "button" wherever the dragged column is currently positioned
-        x = ps->col_movepos - ps->hscrollpos;
-        if (w > 0 && x < x2) {
+        xx = ps->col_movepos - ps->hscrollpos - 2;
+        if (w > 0 && xx < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-            render_column_button(ps, GTK_STATE_FLAG_SELECTED, cr, x-3, 0, w, h);
-//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, ps->header, "button", x, 0, w, h);
+            render_column_button(ps, GTK_STATE_FLAG_SELECTED, cr, xx, 0, w, h);
+//            gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, ps->header, "button", xx, 0, w, h);
 #else
-            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_SELECTED, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", x-3, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_SELECTED, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", xx, 0, w, h);
 #endif
 
             GdkColor gdkfg;
@@ -2439,7 +2440,7 @@ ddb_listview_header_render (DdbListview *ps, cairo_t *cr, int x1, int x2) {
             else {
                 gdkfg = gtk_widget_get_style(ps->theme_button)->fg[GTK_STATE_SELECTED];
             }
-            draw_header_fg(ps, cr, c, &gdkfg, x, x+w, h);
+            draw_header_fg(ps, cr, c, &gdkfg, xx, xx+w, h);
         }
     }
 

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -57,17 +57,13 @@
 //#define REF(it) {if (it) ps->binding->ref (it);}
 #define UNREF(it) {if (it) ps->binding->unref(it);}
 
-// HACK!!
-extern GtkWidget *theme_treeview;
-extern GtkWidget *theme_button;
-
 G_DEFINE_TYPE (DdbListview, ddb_listview, GTK_TYPE_TABLE);
 
 struct _DdbListviewColumn {
     char *title;
     int width;
     float fwidth; // only in autoresize mode
-    int minheight;
+    minheight_cb minheight_cb;
     struct _DdbListviewColumn *next;
     int color_override;
     GdkColor color;
@@ -103,9 +99,9 @@ ddb_listview_list_render (DdbListview *ps, cairo_t *cr, int x, int y, int w, int
 void
 ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h);
 void
-ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h);
+ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int x, int y, int w, int h, int x1, int x2);
 void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter group_it, int group_pinned, int grp_next_y, int x, int y, int w, int h);
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int grp_next_y, int x, int y, int x1, int x2);
 void
 ddb_listview_list_track_dragdrop (DdbListview *ps, int y);
 int
@@ -125,7 +121,7 @@ ddb_listview_get_row_pos (DdbListview *listview, int pos);
 
 ////// header functions ////
 void
-ddb_listview_header_render (DdbListview *ps, cairo_t *cr);
+ddb_listview_header_render (DdbListview *ps, cairo_t *cr, const int x1, const int x2);
 
 ////// column management functions ////
 void
@@ -152,13 +148,13 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
                                         guint            time,
                                         gpointer         user_data);
 
-gboolean
+#if GTK_CHECK_VERSION(3,0,0)
+static gboolean
 ddb_listview_header_draw                 (GtkWidget       *widget,
                                         cairo_t *cr,
                                         gpointer         user_data);
-#if !GTK_CHECK_VERSION(3,0,0)
-
-gboolean
+#else
+static gboolean
 ddb_listview_header_expose_event                 (GtkWidget       *widget,
                                         GdkEventExpose  *event,
                                         gpointer         user_data);
@@ -193,15 +189,18 @@ ddb_listview_list_configure_event            (GtkWidget       *widget,
                                         GdkEventConfigure *event,
                                         gpointer         user_data);
 
-gboolean
+#if GTK_CHECK_VERSION(3,0,0)
+static gboolean
+ddb_listview_list_draw               (GtkWidget       *widget,
+        cairo_t *cr,
+        gpointer         user_data);
+#else
+static gboolean
 ddb_listview_list_expose_event               (GtkWidget       *widget,
                                         GdkEventExpose  *event,
                                         gpointer         user_data);
 
-gboolean
-ddb_listview_list_draw               (GtkWidget       *widget,
-        cairo_t *cr,
-        gpointer         user_data);
+#endif
 
 void
 ddb_listview_list_realize                    (GtkWidget       *widget,
@@ -303,6 +302,7 @@ ddb_listview_init(DdbListview *listview)
     drawctx_init (&listview->listctx);
     drawctx_init (&listview->grpctx);
     drawctx_init (&listview->hdrctx);
+
     listview->rowheight = -1;
 
     listview->col_movepos = -1;
@@ -350,15 +350,13 @@ ddb_listview_init(DdbListview *listview)
     listview->area_selection_start = 0;
     listview->area_selection_end = 0;
 
-    listview->cover_size = -1;
-    listview->new_cover_size = -1;
-    listview->cover_refresh_timeout_id = 0;
     listview->tf_redraw_timeout_id = 0;
     listview->tf_redraw_track_idx = -1;
 
     GtkWidget *hbox;
     GtkWidget *vbox;
 
+    listview->scrollpos = -1;
     gtk_table_resize (GTK_TABLE (listview), 2, 2);
     listview->scrollbar = gtk_vscrollbar_new (GTK_ADJUSTMENT (gtk_adjustment_new (0, 0, 1, 1, 0, 0)));
     gtk_widget_show (listview->scrollbar);
@@ -376,6 +374,15 @@ ddb_listview_init(DdbListview *listview)
     gtk_widget_show (vbox);
     gtk_box_pack_start (GTK_BOX (hbox), vbox, TRUE, TRUE, 0);
 
+    listview->theme_treeview = gtk_tree_view_new();
+    gtk_widget_show(listview->theme_treeview);
+    gtk_widget_set_can_focus(listview->theme_treeview, FALSE);
+    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(listview->theme_treeview), TRUE);
+    gtk_box_pack_start(GTK_BOX(vbox), listview->theme_treeview, FALSE, FALSE, 0);
+    GtkTreeViewColumn *column = gtk_tree_view_column_new();
+    gtk_tree_view_append_column(GTK_TREE_VIEW(listview->theme_treeview), column);
+    gtk_tree_view_column_set_widget(column, gtk_label_new(""));
+
     GtkWidget *sepbox = gtk_vbox_new (FALSE, 0);
     gtk_widget_show (sepbox);
     gtk_container_set_border_width (GTK_CONTAINER (sepbox), 1);
@@ -391,6 +398,7 @@ ddb_listview_init(DdbListview *listview)
     gtk_widget_set_events (listview->header, GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
 
     listview->list = gtk_drawing_area_new ();
+    g_object_ref(listview->list);
     gtk_widget_show (listview->list);
     gtk_box_pack_start (GTK_BOX (vbox), listview->list, TRUE, TRUE, 0);
     gtk_widget_set_can_focus (listview->list, TRUE);
@@ -507,54 +515,55 @@ ddb_listview_init(DdbListview *listview)
 
 GtkWidget * ddb_listview_new()
 {
-   return g_object_newv (ddb_listview_get_type(), 0, NULL);//GTK_WIDGET(gtk_type_new(ddb_listview_get_type()));
+    return g_object_newv (ddb_listview_get_type(), 0, NULL);//GTK_WIDGET(gtk_type_new(ddb_listview_get_type()));
 }
 
 static void
 ddb_listview_destroy(GObject *object)
 {
-  DdbListview *listview;
+    DdbListview *listview;
 
-  g_return_if_fail(object != NULL);
-  g_return_if_fail(DDB_IS_LISTVIEW(object));
+    g_return_if_fail(object != NULL);
+    g_return_if_fail(DDB_IS_LISTVIEW(object));
 
-  listview = DDB_LISTVIEW(object);
+    listview = DDB_LISTVIEW(object);
 
-  ddb_listview_free_groups (listview);
+    ddb_listview_free_groups (listview);
 
-  while (listview->columns) {
-      DdbListviewColumn *next = listview->columns->next;
-      ddb_listview_column_free (listview, listview->columns);
-      listview->columns = next;
-  }
+    while (listview->columns) {
+        DdbListviewColumn *next = listview->columns->next;
+        ddb_listview_column_free (listview, listview->columns);
+        listview->columns = next;
+    }
+    g_object_unref(listview->list);
 
-  if (listview->cursor_sz) {
-      gdk_cursor_unref (listview->cursor_sz);
-      listview->cursor_sz = NULL;
-  }
-  if (listview->cursor_drag) {
-      gdk_cursor_unref (listview->cursor_drag);
-      listview->cursor_drag = NULL;
-  }
-  if (listview->group_format) {
-      free (listview->group_format);
-      listview->group_format = NULL;
-  }
-  if (listview->group_title_bytecode) {
-      free (listview->group_title_bytecode);
-      listview->group_title_bytecode = NULL;
-  }
-  if (listview->tf_redraw_timeout_id) {
-      g_source_remove (listview->tf_redraw_timeout_id);
-      listview->tf_redraw_timeout_id = 0;
-  }
-  if (listview->tf_redraw_track) {
-      listview->binding->unref (listview->tf_redraw_track);
-      listview->tf_redraw_track = NULL;
-  }
-  draw_free (&listview->listctx);
-  draw_free (&listview->grpctx);
-  draw_free (&listview->hdrctx);
+    if (listview->cursor_sz) {
+        gdk_cursor_unref (listview->cursor_sz);
+        listview->cursor_sz = NULL;
+    }
+    if (listview->cursor_drag) {
+        gdk_cursor_unref (listview->cursor_drag);
+        listview->cursor_drag = NULL;
+    }
+    if (listview->group_format) {
+        free (listview->group_format);
+        listview->group_format = NULL;
+    }
+    if (listview->group_title_bytecode) {
+        free (listview->group_title_bytecode);
+        listview->group_title_bytecode = NULL;
+    }
+    if (listview->tf_redraw_timeout_id) {
+        g_source_remove (listview->tf_redraw_timeout_id);
+        listview->tf_redraw_timeout_id = 0;
+    }
+    if (listview->tf_redraw_track) {
+        listview->binding->unref (listview->tf_redraw_track);
+        listview->tf_redraw_track = NULL;
+    }
+    draw_free (&listview->listctx);
+    draw_free (&listview->grpctx);
+    draw_free (&listview->hdrctx);
 }
 
 void
@@ -631,43 +640,30 @@ ddb_listview_groupcheck (DdbListview *listview) {
 }
 
 // returns 1 if X coordinate in list belongs to album art column and 0 if not
-int
+static int
 ddb_listview_is_album_art_column (DdbListview *listview, int x)
 {
     int album_art_column = 0;
     int col_x = -listview->hscrollpos;
     int cnt = ddb_listview_column_get_count (listview);
-    for (int i = 0; i < cnt, col_x <= x; i++) {
-        const char *title;
-        int width;
-        int align_right;
-        col_info_t *info;
-        int minheight;
-        int color_override;
-        GdkColor color;
-        int res = ddb_listview_column_get_info (listview, i, &title, &width, &align_right, &minheight, &color_override, &color, (void **)&info);
-        if (res != -1 && x <= col_x + width && info->id == DB_COLUMN_ALBUM_ART) {
+    for (DdbListviewColumn *c = listview->columns; c && col_x <= x; c = c->next) {
+        if (x <= col_x + c->width && listview->binding->is_album_art_column(c->user_data)) {
             return 1;
         }
-        col_x += width;
+        col_x += c->width;
     }
     return 0;
 }
 
 // returns 1 if column is album art column
-int
-ddb_listview_is_album_art_column_idx (DdbListview *listview, int cidx)
+static int
+ddb_listview_is_album_art_column_idx (DdbListview *listview, int col)
 {
-    const char *title;
-    int width;
-    int align_right;
-    col_info_t *info;
-    int minheight;
-    int color_override;
-    GdkColor color;
-    int res = ddb_listview_column_get_info (listview, cidx, &title, &width, &align_right, &minheight, &color_override, &color, (void **)&info);
-    if (res != -1 && info->id == DB_COLUMN_ALBUM_ART) {
-        return 1;
+    int idx = 0;
+    for (DdbListviewColumn *c = listview->columns; c && idx <= col; c = c->next, idx++) {
+        if (idx == col && listview->binding->is_album_art_column(c->user_data)) {
+            return 1;
+        }
     }
     return 0;
 }
@@ -734,165 +730,165 @@ ddb_listview_list_pickpoint_y (DdbListview *listview, int y, DdbListviewGroup **
     return -1;
 }
 
-int render_idx = 0;
+#if GTK_CHECK_VERSION(3,0,0)
+static void
+render_background (GtkWidget *widget, gchar *class, GtkStateFlags state, gchar *region, GtkRegionFlags region_flags, cairo_t *cr, int x, int y, int w, int h)
+{
+    GtkStyleContext *context = gtk_widget_get_style_context(widget);
+    gtk_style_context_save(context);
+    if (class) {
+        gtk_style_context_add_class(context, class);
+    }
+    if (state) {
+        gtk_style_context_set_state(context, state);
+    }
+    if (region) {
+        gtk_style_context_add_region(context, region, region_flags);
+    }
+    gtk_render_background(context, cr, x, y, w, h);
+    gtk_style_context_restore(context);
+}
+#endif
 
 void
 ddb_listview_list_render (DdbListview *listview, cairo_t *cr, int x, int y, int w, int h) {
-    render_idx = 0;
-    cairo_set_line_width (cr, 1);
-    cairo_set_antialias (cr, CAIRO_ANTIALIAS_NONE);
-    GtkWidget *treeview = theme_treeview;
+    GtkWidget *treeview = listview->theme_treeview;
+    const int scrollx = listview->hscrollpos;
+    const int title_height = listview->grouptitle_height;
+    const int row_height = listview->rowheight;
+    const int total_width = listview->totalwidth;
 
+    if (listview->scrollpos == -1) {
+        return; // too early
+    }
 #if !GTK_CHECK_VERSION(3,0,0)
 // FIXME?
     if (gtk_widget_get_style (treeview)->depth == -1) {
         return; // drawing was called too early
     }
 #endif
-    int idx = 0;
-    int abs_idx = 0;
-    deadbeef->pl_lock ();
-    ddb_listview_groupcheck (listview);
-    // find 1st group
-    DdbListviewGroup *grp = listview->groups;
-    int grp_y = 0;
-    int grp_next_y = 0;
-    DdbListviewGroup *pinned_grp = NULL;
 
-    while (grp && grp_y + grp->height < y + listview->scrollpos) {
-        if (grp_y < listview->scrollpos && grp_y + grp->height >= listview->scrollpos) {
-            pinned_grp = grp;
-            grp->pinned = 1;
-        }
-        grp_y += grp->height;
-        idx += grp->num_items + 1;
-        abs_idx += grp->num_items;
-        grp = grp->next;
-    }
-
+    cairo_set_line_width (cr, 1);
+    cairo_set_antialias (cr, CAIRO_ANTIALIAS_NONE);
     draw_begin (&listview->listctx, cr);
     draw_begin (&listview->grpctx, cr);
 
-    if (grp && !pinned_grp && grp_y < listview->scrollpos) {
+    deadbeef->pl_lock ();
+    ddb_listview_groupcheck (listview);
+    for (DdbListviewGroup *grp_unpin = listview->groups; grp_unpin; grp_unpin = grp_unpin->next) {
+        grp_unpin->pinned = 0;
+    }
+    // find 1st group
+    DdbListviewGroup *grp = listview->groups;
+    int idx = 0;
+    int grp_y = -listview->scrollpos;
+    while (grp && grp_y + grp->height < y) {
+        if (grp_y < 0 && grp_y + grp->height >= 0) {
+            grp->pinned = 1;
+            if (grp->next) {
+                grp->next->pinned = 2;
+            }
+        }
+        grp_y += grp->height;
+        idx += grp->num_items;
+        grp = grp->next;
+    }
+    if (grp_y < 0 && grp_y + grp->height >= 0) {
         grp->pinned = 1;
-        pinned_grp = grp;
-    }
-    else if (grp && pinned_grp && pinned_grp->next == grp) {
-        grp->pinned = 2;
+        if (grp->next) {
+            grp->next->pinned = 2;
+        }
     }
 
-    int ii = 0;
-    while (grp && grp_y < y + h + listview->scrollpos) {
+    while (grp && grp_y < y + h) {
+        const int grp_height = title_height + grp->num_items * row_height;
+        const int grp_height_total = grp->height;
+
         DdbListviewIter it = grp->head;
-        int grp_height = listview->grouptitle_height + grp->num_items * listview->rowheight;
-        int grp_height_total = grp->height;
-        int group_idx = idx;
-
-        if (grp_y >= y + h + listview->scrollpos) {
-            break;
-        }
-        listview->binding->ref (it);
-
-        grp_next_y = grp_y + grp_height_total;
-        for (int i = 0; i < grp->num_items; i++) {
-            ii++;
-            int grp_row_y = grp_y + listview->grouptitle_height + i * listview->rowheight;
-            if (grp_row_y >= y + h + listview->scrollpos) {
-                break;
+        listview->binding->ref(it);
+        for (int i = 0, yy = grp_y + listview->grouptitle_height; it && i < grp->num_items && yy < y + h; i++, yy += row_height) {
+            if (yy + row_height >= y) {
+// GTK does this already, plus we are going to draw over every inch of it
+//                GtkStyle *st = gtk_widget_get_style (listview->list);
+//                GdkColor *clr = &st->bg[GTK_STATE_NORMAL];
+//                cairo_set_source_rgb (cr, clr->red/65535., clr->green/65535., clr->blue/65535.);
+//                cairo_rectangle (cr, -scrollx, yy, total_width, row_height);
+//                cairo_fill (cr);
+                ddb_listview_list_render_row_background(listview, cr, it, i & 1, idx+i == listview->binding->cursor() ? 1 : 0, -scrollx, yy, total_width, row_height);
+                ddb_listview_list_render_row_foreground(listview, cr, it, -scrollx, yy, total_width, row_height, x, x+w);
             }
-            if (grp_y + listview->grouptitle_height + (i+1) * listview->rowheight >= y + listview->scrollpos
-                    && grp_row_y < y + h + listview->scrollpos) {
-                GtkStyle *st = gtk_widget_get_style (listview->list);
-                gdk_cairo_set_source_color (cr, &st->bg[GTK_STATE_NORMAL]);
-                cairo_rectangle (cr, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
-                cairo_fill (cr);
-                ddb_listview_list_render_row_background (listview, cr, it, i & 1, (abs_idx+i) == listview->binding->cursor () ? 1 : 0, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
-                ddb_listview_list_render_row_foreground (listview, cr, it, (idx + 1 + i) & 1, (idx+i) == listview->binding->cursor () ? 1 : 0, -listview->hscrollpos, grp_row_y - listview->scrollpos, listview->totalwidth, listview->rowheight);
-            }
-            DdbListviewIter next = listview->binding->next (it);
-            listview->binding->unref (it);
+            DdbListviewIter next = listview->binding->next(it);
+            listview->binding->unref(it);
             it = next;
-            if (!it) {
-                break; // sanity check, in case groups were not rebuilt yet
-            }
         }
-        idx += grp->num_items + 1;
-        abs_idx += grp->num_items;
+        if (it) {
+            listview->binding->unref(it);
+        }
+        idx += grp->num_items;
 
-        int filler = grp_height_total - (grp_height);
+        const int filler = grp_height_total - grp_height;
         if (filler > 0) {
-            int theming = !gtkui_override_listview_colors ();
-            if (theming) {
+            const int yy = grp_y + grp_height;
+            if (!gtkui_override_listview_colors()) {
 #if GTK_CHECK_VERSION(3,0,0)
-                gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, "cell_even_ruled", x, grp_y - listview->scrollpos + grp_height, w, filler);
+                render_background(treeview, NULL, GTK_STATE_FLAG_NORMAL, GTK_STYLE_REGION_ROW, GTK_REGION_EVEN, cr, x-1, yy-1, w+2, filler+2);
+//                gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, "cell_even_ruled", x, grp_y + grp_height, w, filler);
 #else
-                gtk_paint_flat_box (gtk_widget_get_style (treeview), gtk_widget_get_window (listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, treeview, "cell_even_ruled", x, grp_y - listview->scrollpos + grp_height, w, filler);
+                gtk_paint_flat_box(gtk_widget_get_style(treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, treeview, "cell_even_ruled", x, yy, w, filler);
 #endif
             }
             else {
                 GdkColor clr;
-                gtkui_get_listview_even_row_color (&clr);
-                gdk_cairo_set_source_color (cr, &clr);
-                cairo_rectangle (cr, x, grp_y - listview->scrollpos + grp_height, w, filler);
-                cairo_fill (cr);
+                gtkui_get_listview_even_row_color(&clr);
+                cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
+                cairo_rectangle(cr, x, yy, w, filler);
+                cairo_fill(cr);
             }
         }
 
         // draw album art
-        ddb_listview_list_render_album_art (listview, cr, grp->head, grp->pinned, grp_next_y - listview->scrollpos, -listview->hscrollpos, grp_y + listview->grouptitle_height - listview->scrollpos, listview->totalwidth, grp_height_total);
+        const int grp_next_y = grp_y + grp_height_total;
+        ddb_listview_list_render_album_art(listview, cr, grp, grp_next_y, -scrollx, grp_y + title_height, x, x + w);
+
         if (grp->pinned == 1 && gtkui_groups_pinned && y <= 0) {
             // draw pinned group title
             int pushback = 0;
-            if (grp_next_y - listview->scrollpos <= listview->grouptitle_height) {
-                pushback = listview->grouptitle_height - (grp_next_y - listview->scrollpos);
+            if (grp_next_y <= title_height) {
+                pushback = title_height - grp_next_y;
             }
-            ddb_listview_list_render_row_background (listview, cr, NULL, 1, 0, -listview->hscrollpos, y - pushback, listview->totalwidth, listview->grouptitle_height);
-            if (listview->binding->draw_group_title && listview->grouptitle_height > 0) {
-                listview->binding->draw_group_title (listview, cr, grp->head, PL_MAIN, -listview->hscrollpos, y - pushback, listview->totalwidth, listview->grouptitle_height);
+            ddb_listview_list_render_row_background(listview, cr, NULL, 1, 0, -scrollx, y - pushback, total_width, title_height);
+            if (listview->binding->draw_group_title && title_height > 0) {
+                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, -scrollx, y - pushback, total_width, title_height);
             }
         }
-        else if (grp_y + listview->grouptitle_height >= y + listview->scrollpos && grp_y < y + h + listview->scrollpos) {
+        else if (grp_y + title_height >= y && grp_y < y + h) {
             // draw normal group title
-            ddb_listview_list_render_row_background (listview, cr, NULL, 1, 0, -listview->hscrollpos, grp_y - listview->scrollpos, listview->totalwidth, listview->grouptitle_height);
-            if (listview->binding->draw_group_title && listview->grouptitle_height > 0) {
-                listview->binding->draw_group_title (listview, cr, grp->head, PL_MAIN, -listview->hscrollpos, grp_y - listview->scrollpos, listview->totalwidth, listview->grouptitle_height);
+            ddb_listview_list_render_row_background(listview, cr, NULL, 1, 0, -scrollx, grp_y, total_width, title_height);
+            if (listview->binding->draw_group_title && title_height > 0) {
+                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, -scrollx, grp_y, total_width, title_height);
             }
         }
 
-        if (it) {
-            listview->binding->unref (it);
-        }
         grp_y += grp_height_total;
-        if (grp->pinned == 1) {
-            grp = grp->next;
-            if (grp) {
-                grp->pinned = 2;
-            }
-        }
-        else {
-            grp = grp->next;
-            if (grp) {
-                grp->pinned = 0;
-            }
-        }
+        grp = grp->next;
     }
-    if (grp_y < y + h + listview->scrollpos) {
-        int hh = y + h - (grp_y - listview->scrollpos);
-//        gdk_draw_rectangle (listview->list->window, listview->list->style->bg_gc[GTK_STATE_NORMAL], TRUE, x, grp_y - listview->scrollpos, w, hh);
-        int theming = !gtkui_override_listview_colors ();
-        if (theming) {
+
+    if (grp_y < y + h) {
+        const int hh = y + h - grp_y;
+        if (!gtkui_override_listview_colors()) {
 #if GTK_CHECK_VERSION(3,0,0)
-            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, "cell_even_ruled", x, grp_y - listview->scrollpos, w, hh);
+            render_background(treeview, NULL, GTK_STATE_FLAG_NORMAL, GTK_STYLE_REGION_ROW, GTK_REGION_EVEN, cr, x-1, grp_y-1, w+2, hh+2);
+//            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, "cell_even_ruled", x, grp_y, w, hh);
 #else
-            gtk_paint_flat_box (gtk_widget_get_style (treeview), listview->list->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, treeview, "cell_even_ruled", x, grp_y - listview->scrollpos, w, hh);
+            gtk_paint_flat_box(gtk_widget_get_style(treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, treeview, "cell_even_ruled", x, grp_y, w, hh);
 #endif
         }
         else {
             GdkColor clr;
-            gtkui_get_listview_even_row_color (&clr);
-            cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-            cairo_rectangle (cr, x, grp_y - listview->scrollpos, w, hh);
-            cairo_fill (cr);
+            gtkui_get_listview_even_row_color(&clr);
+            cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
+            cairo_rectangle(cr, x, grp_y, w, hh);
+            cairo_fill(cr);
         }
     }
     deadbeef->pl_unlock ();
@@ -912,7 +908,7 @@ ddb_listview_draw_dnd_marker (DdbListview *ps, cairo_t *cr) {
     gtk_widget_get_allocation (widget, &a);
     GdkColor clr;
     gtkui_get_listview_cursor_color (&clr);
-    cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.0);
+    cairo_set_source_rgb (cr, clr.red/65535., clr.green/65535., clr.blue/65535.0);
     cairo_rectangle (cr, 0, drag_motion_y-1, a.width, 3);
     cairo_fill (cr);
     cairo_rectangle (cr, 0, drag_motion_y-3, 3, 7);
@@ -948,23 +944,22 @@ ddb_listview_update_fonts (DdbListview *ps)
 }
 
 #if GTK_CHECK_VERSION(3,0,0)
-gboolean
+static gboolean
 ddb_listview_list_draw               (GtkWidget       *widget,
         cairo_t *cr,
         gpointer         user_data)
 {
-    DdbListview *ps = DDB_LISTVIEW (g_object_get_data (G_OBJECT (widget), "owner"));
-    widget = ps->list;
-
-    // FIXME: clip region
-    ddb_listview_list_render (ps, cr, 0, 0, gtk_widget_get_allocated_width (widget), gtk_widget_get_allocated_height (widget));
-    if (ps->drag_motion_y >= 0/* && ps->drag_motion_y-ps->scrollpos-3 < event->area.y+event->area.height && ps->drag_motion_y-ps->scrollpos+3 >= event->area.y*/) {
-        ddb_listview_draw_dnd_marker (ps, cr);
+    DdbListview *ps = DDB_LISTVIEW(g_object_get_data(G_OBJECT(widget), "owner"));
+    GdkRectangle clip;
+    gdk_cairo_get_clip_rectangle(cr, &clip);
+    ddb_listview_list_render(ps, cr, clip.x, clip.y, clip.width, clip.height);
+    if (ps->drag_motion_y >= 0 && ps->drag_motion_y-ps->scrollpos-3 < clip.y+clip.height && ps->drag_motion_y-ps->scrollpos+3 >= clip.y) {
+        ddb_listview_draw_dnd_marker(ps, cr);
     }
-    return FALSE;
+    return TRUE;
 }
 #else
-gboolean
+static gboolean
 ddb_listview_list_expose_event               (GtkWidget       *widget,
         GdkEventExpose  *event,
         gpointer         user_data)
@@ -978,7 +973,7 @@ ddb_listview_list_expose_event               (GtkWidget       *widget,
         ddb_listview_draw_dnd_marker (ps, cr);
     }
     cairo_destroy (cr);
-    return FALSE;
+    return TRUE;
 }
 #endif
 
@@ -989,7 +984,7 @@ ddb_listview_vscroll_event               (GtkWidget       *widget,
 {
     DdbListview *ps = DDB_LISTVIEW (g_object_get_data (G_OBJECT (widget), "owner"));
 
-	GdkEventScroll *ev = (GdkEventScroll*)event;
+    GdkEventScroll *ev = (GdkEventScroll*)event;
 
     GtkWidget *rangeh = ps->hscrollbar;
     GtkWidget *rangev = ps->scrollbar;
@@ -1034,7 +1029,7 @@ ddb_listview_vscroll_value_changed            (GtkRange        *widget,
         ps->binding->vscroll_changed (newscroll);
     }
     if (ps->block_redraw_on_scroll) {
-        ps->scrollpos = newscroll; 
+        ps->scrollpos = newscroll;
         return;
     }
     if (newscroll != ps->scrollpos) {
@@ -1080,8 +1075,14 @@ ddb_listview_list_drag_motion                (GtkWidget       *widget,
     else {
         GdkModifierType mask;
 
-        gdk_window_get_pointer (gtk_widget_get_window (widget),
-                NULL, NULL, &mask);
+    GdkWindow *win = gtk_widget_get_window (widget);
+#if GTK_CHECK_VERSION(3,0,0)
+        GdkDeviceManager *device_manager = gdk_display_get_device_manager (gdk_window_get_display (win));
+        GdkDevice *pointer = gdk_device_manager_get_client_pointer (device_manager);
+        gdk_window_get_device_position (win, pointer, &x, &y, &mask);
+#else
+        gdk_window_get_pointer (win, NULL, NULL, &mask);
+#endif
         if (mask & GDK_CONTROL_MASK) {
             gdk_drag_status (drag_context, GDK_ACTION_COPY, time);
         }
@@ -1257,7 +1258,6 @@ ddb_listview_get_hscroll_pos (DdbListview *listview) {
 }
 
 #define MIN_COLUMN_WIDTH 16
-#define COLHDR_ANIM_TIME 0.2f
 
 void
 ddb_listview_list_setup_vscroll (DdbListview *ps) {
@@ -1376,7 +1376,7 @@ ddb_listview_draw_row (DdbListview *listview, int row, DdbListviewIter it) {
 void
 ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h) {
     // draw background
-    GtkWidget *treeview = theme_treeview;
+    GtkWidget *treeview = ps->theme_treeview;
     int theming = !gtkui_override_listview_colors ();
 
     if (theming) {
@@ -1392,7 +1392,8 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
         if (theming) {
             // draw background for selection -- workaround for New Wave theme (translucency)
 #if GTK_CHECK_VERSION(3,0,0)
-            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
+            render_background(ps->theme_treeview, NULL, GTK_STATE_FLAG_NORMAL, GTK_STYLE_REGION_ROW, even ? GTK_REGION_EVEN : GTK_REGION_ODD, cr, x, y-1, w, h+2);
+//            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
 #else
             gtk_paint_flat_box (gtk_widget_get_style (treeview), ps->list->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
 #endif
@@ -1400,7 +1401,7 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
         else {
             GdkColor clr;
             even ? gtkui_get_listview_even_row_color (&clr) : gtkui_get_listview_odd_row_color (&clr);
-            gdk_cairo_set_source_color (cr, &clr);
+            cairo_set_source_rgb (cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
             cairo_rectangle (cr, x, y, w, h);
             cairo_fill (cr);
         }
@@ -1409,7 +1410,8 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
     if (sel) {
         if (theming) {
 #if GTK_CHECK_VERSION(3,0,0)
-            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_SELECTED, GTK_SHADOW_NONE, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x-1, y-1, w+1, h+1);
+            render_background(ps->theme_treeview, GTK_STYLE_CLASS_CELL, GTK_STATE_FLAG_SELECTED, GTK_STYLE_REGION_ROW, even ? GTK_REGION_EVEN : GTK_REGION_ODD, cr, x, y, w, h);
+//            gtk_paint_flat_box (gtk_widget_get_style (treeview), cr, GTK_STATE_SELECTED, GTK_SHADOW_NONE, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x-1, y-1, w+1, h+1);
 #else
             gtk_paint_flat_box (gtk_widget_get_style (treeview), ps->list->window, GTK_STATE_SELECTED, GTK_SHADOW_NONE, NULL, treeview, even ? "cell_even_ruled" : "cell_odd_ruled", x, y, w, h);
             //            if (gtk_widget_has_focus (ps->list)) {
@@ -1419,83 +1421,62 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
         }
         else {
             GdkColor clr;
-#if !GTK_CHECK_VERSION(3,0,0)
-            GdkGC *gc = gdk_gc_new (ps->list->window);
-            gdk_gc_set_rgb_fg_color (gc, (gtkui_get_listview_selection_color (&clr), &clr));
-            gdk_draw_rectangle (ps->list->window, gc, TRUE, x, y, w, h);
-            g_object_unref (gc);
-
-#else
             gtkui_get_listview_selection_color (&clr);
-            cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
+            cairo_set_source_rgb (cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
             cairo_rectangle (cr, x, y, w, h);
             cairo_fill (cr);
-#endif
         }
     }
     if (cursor && gtk_widget_has_focus (ps->list)) {
         // not all gtk engines/themes render focus rectangle in treeviews
         // but we want it anyway
-        //treeview->style->fg_gc[GTK_STATE_NORMAL]
         GdkColor clr;
-#if !GTK_CHECK_VERSION(3,0,0)
-        GdkGC *gc = gdk_gc_new (ps->list->window);
-        gdk_gc_set_rgb_fg_color (gc, (gtkui_get_listview_cursor_color (&clr), &clr));
-        gdk_draw_rectangle (ps->list->window, gc, FALSE, x, y, w-1, h-1);
-        g_object_unref (gc);
-#else
         gtkui_get_listview_cursor_color (&clr);
-        cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
+        cairo_set_source_rgb (cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
         cairo_rectangle (cr, x+1, y+1, w-1, h-1);
         cairo_stroke (cr);
-#endif
     }
 }
 
 void
-ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int even, int cursor, int x, int y, int w, int h) {
+ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int x, int y, int w, int h, int x1, int x2) {
     int width, height;
     GtkAllocation a;
     gtk_widget_get_allocation (ps->list, &a);
     width = a.width;
     height = a.height;
     if (it && ps->binding->is_selected (it)) {
-        GdkColor *clr = &gtk_widget_get_style (theme_treeview)->fg[GTK_STATE_SELECTED];
-        float rgb[3] = { clr->red/65535.f, clr->green/65535.f, clr->blue/65535.f };
+        GdkColor *clr = &gtk_widget_get_style (ps->theme_treeview)->fg[GTK_STATE_SELECTED];
+        float rgb[3] = { clr->red/65535., clr->green/65535., clr->blue/65535. };
         draw_set_fg_color (&ps->listctx, rgb);
     }
     else {
-        GdkColor *clr = &gtk_widget_get_style (theme_treeview)->fg[GTK_STATE_NORMAL];
-        float rgb[3] = { clr->red/65535.f, clr->green/65535.f, clr->blue/65535.f };
+        GdkColor *clr = &gtk_widget_get_style (ps->theme_treeview)->fg[GTK_STATE_NORMAL];
+        float rgb[3] = { clr->red/65535., clr->green/65535., clr->blue/65535. };
         draw_set_fg_color (&ps->listctx, rgb);
     }
     DdbListviewColumn *c;
     int cidx = 0;
-    for (c = ps->columns; c; c = c->next, cidx++) {
-        int cw = c->width;
-        if (!ddb_listview_is_album_art_column_idx (ps, cidx)) {
-            ps->binding->draw_column_data (ps, cr, it, cidx, PL_MAIN, x, y, cw, h);
+    for (c = ps->columns; c && x < x2; x += c->width, c = c->next, cidx++) {
+        if (x + c->width > x1 && !ddb_listview_is_album_art_column_idx (ps, cidx)) {
+            ps->binding->draw_column_data (ps, cr, it, cidx, PL_MAIN, x, y, c->width, h);
         }
-        x += cw;
     }
 }
 
 void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewIter group_it, int group_pinned, int grp_next_y, int x, int y, int w, int h) {
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int grp_next_y, int x, int y, int x1, int x2) {
     DdbListviewColumn *c;
-    int cidx = 0;
-    for (c = ps->columns; c; c = c->next, cidx++) {
-        int cw = c->width;
-        if (ddb_listview_is_album_art_column_idx (ps, cidx)) {
-            ps->binding->draw_album_art (ps, cr, ps->grouptitle_height > 0 ? group_it : NULL, cidx, group_pinned, grp_next_y, x, y, cw, h);
+    for (c = ps->columns; c; x += c->width, c = c->next) {
+        if (ps->binding->is_album_art_column(c->user_data) && x + c->width > x1 && x < x2) {
+            ps->binding->draw_album_art(ps, cr, ps->grouptitle_height > 0 ? grp->head : NULL, c->user_data, grp->pinned, grp_next_y, x, y, c->width, grp->height);
         }
-        x += cw;
     }
 }
 
 void
 ddb_listview_header_expose (DdbListview *ps, cairo_t *cr, int x, int y, int w, int h) {
-    ddb_listview_header_render (ps, cr);
+    ddb_listview_header_render (ps, cr, x, x+w);
 }
 
 void
@@ -2045,7 +2026,7 @@ ddb_listview_list_mousemove (DdbListview *ps, GdkEventMotion *ev, int ex, int ey
 void
 ddb_listview_list_set_hscroll (DdbListview *ps, int newscroll) {
     if (ps->block_redraw_on_scroll) {
-        ps->hscrollpos = newscroll; 
+        ps->hscrollpos = newscroll;
         return;
     }
 //    if (newscroll != ps->hscrollpos)
@@ -2272,7 +2253,7 @@ ddb_listview_list_track_dragdrop (DdbListview *ps, int y) {
     // FIXME
 //    ddb_listview_draw_dnd_marker (ps, cr);
 #endif
-    
+
     if (y < 10) {
         ps->scroll_pointer_y = y;
         ps->scroll_mode = 1;
@@ -2312,185 +2293,159 @@ ddb_listview_list_drag_end                   (GtkWidget       *widget,
     ps->scroll_pointer_y = -1;
 }
 
-// #define HEADERS_GTKTHEME
+static void
+draw_cairo_line(cairo_t *cr, GdkColor *color, const int x1, const int y1, const int x2, const int y2) {
+    cairo_set_source_rgb (cr, color->red/65535., color->green/65535., color->blue/65535.);
+    cairo_move_to (cr, x1, y1);
+    cairo_line_to (cr, x2, y2);
+    cairo_stroke (cr);
+}
+
+static void
+draw_header_fg(DdbListview *ps, cairo_t *cr, DdbListviewColumn *c, GdkColor *clr, const int x, const int xx, const int h) {
+    int text_width = c->width - 10;
+    if (c->sort_order) {
+        const int arrow_sz = 10;
+        text_width -= arrow_sz;
+#if GTK_CHECK_VERSION(3,0,0)
+//                gtk_paint_arrow (gtk_widget_get_style (ps->header), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, ps->header, NULL, dir, TRUE, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz, arrow_sz);
+        gtk_render_arrow(gtk_widget_get_style_context(ps->theme_treeview), cr, c->sort_order*G_PI, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz);
+#else
+        const int dir = c->sort_order == 1 ? GTK_ARROW_DOWN : GTK_ARROW_UP;
+        gtk_paint_arrow(ps->header->style, ps->header->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, ps->header, NULL, dir, TRUE, xx-arrow_sz-5, h/2-arrow_sz/2, arrow_sz, arrow_sz);
+#endif
+    }
+
+    float fg[3] = {clr->red/65535., clr->green/65535., clr->blue/65535.};
+    draw_set_fg_color(&ps->hdrctx, fg);
+    draw_text_custom(&ps->hdrctx, x+2, 3, text_width, 0, DDB_COLUMN_FONT, 0, 0, c->title);
+}
 
 void
-ddb_listview_header_render (DdbListview *ps, cairo_t *cr) {
+ddb_listview_header_render (DdbListview *ps, cairo_t *cr, const int x1, const int x2) {
     cairo_set_line_width (cr, 1);
     cairo_set_antialias (cr, CAIRO_ANTIALIAS_NONE);
-    GtkWidget *widget = ps->header;
-    int x = -ps->hscrollpos;
-    int w = 100;
     GtkAllocation a;
-    gtk_widget_get_allocation (widget, &a);
-    int h = a.height;
-    const char *detail = "button";
+    gtk_widget_get_allocation (ps->header, &a);
+    draw_begin(&ps->hdrctx, cr);
+    const int h = a.height;
 
     // fill background and draw bottom line
-#if !HEADERS_GTKTHEME
-    GdkColor clr;
-    gtkui_get_tabstrip_base_color (&clr);
-    cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-    cairo_rectangle (cr, 0, 0,  a.width, a.height);
-    cairo_fill (cr);
-    gtkui_get_tabstrip_dark_color (&clr);
-    cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-    cairo_move_to (cr, 0, a.height);
-    cairo_line_to (cr, a.width, a.height);
-    cairo_stroke (cr);
-#else
+    if (gtkui_override_listview_colors()) {
+        GdkColor clr;
+        gtkui_get_tabstrip_base_color(&clr);
+        cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
+        cairo_rectangle(cr, 0, 0, a.width, h);
+        cairo_fill(cr);
+        gtkui_get_tabstrip_dark_color(&clr);
+        draw_cairo_line(cr, &clr, 0, h, a.width, h);
+    }
+    else {
 #if GTK_CHECK_VERSION(3,0,0)
-    gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_NORMAL, GTK_SHADOW_OUT, widget, detail, -10, -10, a.width+20, a.height+20);
+    //    gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_NORMAL, GTK_SHADOW_OUT, ps->header, detail, -10, -10, a.width+20, a.height+20);
+        render_background(ps->theme_button, NULL, GTK_STATE_FLAG_NORMAL, GTK_STYLE_REGION_COLUMN_HEADER, 0, cr, -2, -2, a.width+4, h+4);
 #else
-    gtk_paint_box (theme_button->style, ps->header->window, GTK_STATE_NORMAL, GTK_SHADOW_OUT, NULL, widget, detail, -10, -10, a.width+20, a.height+20);
+        gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_NORMAL, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", -2, -2, a.width+4, h+4);
 #endif
-    clr = gtk_widget_get_style (widget)->mid[GTK_STATE_NORMAL]
-    cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-    cairo_move_to (cr, 0, a.height-1);
-    cairo_line_to (cr, a.width, a.height-1);
-    cairo_stroke (cr);
-#endif
-    draw_begin (&ps->hdrctx, cr);
-    x = -ps->hscrollpos;
-    DdbListviewColumn *c;
-    int need_draw_moving = 0;
-    int idx = 0;
-    for (c = ps->columns; c; c = c->next, idx++) {
-        w = c->width;
-        int xx = x;
-#if 0
-        if (colhdr_anim.anim_active) {
-            if (idx == colhdr_anim.c2) {
-                xx = colhdr_anim.ax1;
-            }
-            else if (idx == colhdr_anim.c1) {
-                xx = colhdr_anim.ax2;
-            }
-        }
-#endif
-        if (ps->header_dragging < 0 || idx != ps->header_dragging) {
-            if (xx >= a.width) {
-                continue;
-            }
-            int arrow_sz = 10;
-            int sort = c->sort_order;
-            if (w > 0) {
-#if !HEADERS_GTKTHEME
-                gtkui_get_tabstrip_dark_color (&clr);
-                cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-                cairo_move_to (cr, xx+w - 2, 2);
-                cairo_line_to (cr, xx+w - 2, h-4);
-                cairo_stroke (cr);
-                
-                gtkui_get_tabstrip_light_color (&clr);
-                cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
+        draw_cairo_line(cr, &gtk_widget_get_style(ps->header)->mid[GTK_STATE_NORMAL], 0, h, a.width, h);
+    }
 
-                cairo_move_to (cr, xx+w - 1, 2);
-                cairo_line_to (cr, xx+w - 1, h-4);
-                cairo_stroke (cr);
-#else
-#if GTK_CHECK_VERSION(3,0,0)
-                gtk_paint_vline (gtk_widget_get_style (widget), cr, GTK_STATE_NORMAL, widget, NULL, 2, h-4, xx+w - 3);
-#else
-                gtk_paint_vline (widget->style, ps->header->window, GTK_STATE_NORMAL, NULL, widget, NULL, 2, h-4, xx+w - 3);
-#endif
-#endif
-                GdkColor *gdkfg;
-                if (!gtkui_override_listview_colors ()) {
-                    gdkfg = &gtk_widget_get_style (theme_button)->fg[0];
+    int x = -ps->hscrollpos;
+    int idx = 0;
+    for (DdbListviewColumn *c = ps->columns; c && x < x2; c = c->next, idx++) {
+        const int xx = x + c->width;
+
+        if (idx != ps->header_dragging && xx >= x1) {
+            GdkColor gdkfg;
+            if (gtkui_override_listview_colors()) {
+                gtkui_get_listview_column_text_color(&gdkfg);
+            }
+            else {
+                gdkfg = gtk_widget_get_style(ps->theme_button)->fg[GTK_STATE_NORMAL];
+            }
+            draw_header_fg(ps, cr, c, &gdkfg, x, xx, h);
+
+            if (c->width > 0 && ps->header_dragging != idx + 1) {
+                if (gtkui_override_listview_colors()) {
+                    GdkColor clr;
+                    gtkui_get_tabstrip_dark_color (&clr);
+                    draw_cairo_line(cr, &clr, xx-2, 2, xx-2, h-4);
+                    gtkui_get_tabstrip_light_color (&clr);
+                    draw_cairo_line(cr, &clr, xx-1, 2, xx-1, h-4);
                 }
                 else {
-                    gdkfg = (gtkui_get_listview_column_text_color (&clr), &clr);
-                }
-                float fg[3] = {(float)gdkfg->red/0xffff, (float)gdkfg->green/0xffff, (float)gdkfg->blue/0xffff};
-                draw_set_fg_color (&ps->hdrctx, fg);
-                int ww = w-10;
-                if (sort) {
-                    ww -= arrow_sz;
-                    if (ww < 0) {
-                        ww = 0;
-                    }
-                }
-                draw_text_custom (&ps->hdrctx, xx + 5, 3, ww, 0, DDB_COLUMN_FONT, 0, 0, c->title);
-            }
-            if (sort) {
-                int dir = sort == 1 ? GTK_ARROW_DOWN : GTK_ARROW_UP;
 #if GTK_CHECK_VERSION(3,0,0)
-                gtk_paint_arrow (gtk_widget_get_style (widget), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, widget, NULL, dir, TRUE, xx + w-arrow_sz-5, a.height/2-arrow_sz/2, arrow_sz, arrow_sz);
+                    GtkStyleContext *context = gtk_widget_get_style_context(ps->theme_treeview);
+                    gtk_style_context_save(context);
+                    gtk_style_context_add_class(context, GTK_STYLE_CLASS_SEPARATOR);
+                    gtk_render_frame(context, cr, xx-2, 2, 2, h-4);
+                    gtk_style_context_restore(context);
+//                    gtk_paint_vline (gtk_widget_get_style (ps->header), cr, GTK_STATE_NORMAL, ps->header, NULL, 2, h-4, xx - 3);
 #else
-                gtk_paint_arrow (widget->style, ps->header->window, GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, widget, NULL, dir, TRUE, xx + w-arrow_sz-5, a.height/2-arrow_sz/2, arrow_sz, arrow_sz);
+                    gtk_paint_vline (ps->header->style, ps->header->window, GTK_STATE_NORMAL, NULL, ps->header, NULL, 2, h-4, xx-2);
 #endif
+                }
             }
         }
-        else {
-            need_draw_moving = 1;
-        }
-        x += w;
+        x = xx;
     }
-    if (need_draw_moving) {
+
+    if (ps->header_dragging != -1) {
         x = -ps->hscrollpos;
         idx = 0;
-        for (c = ps->columns; c; c = c->next, idx++) {
-            w = c->width;
-            if (idx == ps->header_dragging) {
-#if 0
-                if (colhdr_anim.anim_active) {
-                    if (idx == colhdr_anim.c2) {
-                        x = colhdr_anim.ax1;
-                    }
-                    else if (idx == colhdr_anim.c1) {
-                        x = colhdr_anim.ax2;
-                    }
-                }
-#endif
-                // draw empty slot
-                if (x < a.width) {
+        DdbListviewColumn *c = ps->columns;
+        while (c && idx++ != ps->header_dragging) {
+            x += c->width;
+            c = c->next;
+        }
+
+        // draw empty slot
+        const int w = c->width;
+        if (x < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-                    gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, widget, "button", x, 0, w, h);
+            render_background(ps->theme_button, NULL, GTK_STATE_FLAG_ACTIVE, NULL, 0, cr, x-3, 0, w, h);
+//                    gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, ps->header, "button", x, 0, w, h);
 #else
-                    gtk_paint_box (theme_button->style, ps->header->window, GTK_STATE_ACTIVE, GTK_SHADOW_ETCHED_IN, NULL, widget, "button", x, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_ACTIVE, GTK_SHADOW_IN, NULL, ps->theme_button, "button", x-3, 0, w, h);
 #endif
-                }
-                x = ps->col_movepos - ps->hscrollpos;
-                if (x >= a.width) {
-                    break;
-                }
-                if (w > 0) {
+        }
+
+        x = ps->col_movepos - ps->hscrollpos;
+        if (w > 0 && x < x2) {
 #if GTK_CHECK_VERSION(3,0,0)
-                    gtk_paint_box (gtk_widget_get_style (theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, widget, "button", x, 0, w, h);
+            render_background(ps->theme_button, NULL, GTK_STATE_FLAG_PRELIGHT, NULL, 0, cr, x-3, 0, w, h);
+//                    gtk_paint_box (gtk_widget_get_style (ps->theme_button), cr, GTK_STATE_SELECTED, GTK_SHADOW_OUT, ps->header, "button", x, 0, w, h);
 #else
-                    gtk_paint_box (theme_button->style, ps->header->window, GTK_STATE_SELECTED, GTK_SHADOW_OUT, NULL, widget, "button", x, 0, w, h);
+            gtk_paint_box(gtk_widget_get_style(ps->theme_button), gtk_widget_get_window(ps->header), GTK_STATE_PRELIGHT, GTK_SHADOW_OUT, NULL, ps->theme_button, "button", x-3, 0, w, h);
 #endif
-                    GdkColor *gdkfg = &gtk_widget_get_style (theme_button)->fg[GTK_STATE_SELECTED];
-                    float fg[3] = {(float)gdkfg->red/0xffff, (float)gdkfg->green/0xffff, (float)gdkfg->blue/0xffff};
-                    draw_set_fg_color (&ps->hdrctx, fg);
-                    draw_text_custom (&ps->hdrctx, x + 5, 3, c->width-10, 0, DDB_COLUMN_FONT, 0, 0, c->title);
-                }
-                break;
+
+            GdkColor gdkfg;
+            if (gtkui_override_listview_colors()) {
+                gtkui_get_listview_selected_text_color(&gdkfg);
             }
-            x += w;
+            else {
+                gdkfg = gtk_widget_get_style(ps->theme_button)->fg[GTK_STATE_SELECTED];
+            }
+            draw_header_fg(ps, cr, c, &gdkfg, x, x+w, h);
         }
     }
+
     draw_end (&ps->hdrctx);
 }
 
-gboolean
+#if GTK_CHECK_VERSION(3,0,0)
+static gboolean
 ddb_listview_header_draw                 (GtkWidget       *widget,
                                         cairo_t *cr,
                                         gpointer         user_data) {
     DdbListview *ps = DDB_LISTVIEW (g_object_get_data (G_OBJECT (widget), "owner"));
-    // FIXME: clip region
-    cairo_set_line_width (cr, 1);
-    cairo_set_antialias (cr, CAIRO_ANTIALIAS_NONE);
-    GtkAllocation a;
-    gtk_widget_get_allocation (widget, &a);
-    ddb_listview_header_expose (ps, cr, 0, 0, a.width, a.height);
-    return FALSE;
+    GdkRectangle clip;
+    gdk_cairo_get_clip_rectangle(cr, &clip);
+    ddb_listview_header_expose (ps, cr, clip.x, clip.y, clip.width, clip.height);
+    return TRUE;
 }
-
-
-#if !GTK_CHECK_VERSION(3,0,0)
-gboolean
+#else
+static gboolean
 ddb_listview_header_expose_event                 (GtkWidget       *widget,
                                         GdkEventExpose  *event,
                                         gpointer         user_data)
@@ -2499,7 +2454,7 @@ ddb_listview_header_expose_event                 (GtkWidget       *widget,
     cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
     ddb_listview_header_expose (ps, cr, event->area.x, event->area.y, event->area.width, event->area.height);
     cairo_destroy (cr);
-    return FALSE;
+    return TRUE;
 }
 #endif
 
@@ -2638,6 +2593,11 @@ ddb_listview_header_realize                      (GtkWidget       *widget,
     DdbListview *listview = DDB_LISTVIEW (g_object_get_data (G_OBJECT (widget), "owner"));
     listview->cursor_sz = gdk_cursor_new (GDK_SB_H_DOUBLE_ARROW);
     listview->cursor_drag = gdk_cursor_new (GDK_FLEUR);
+    listview->theme_button = gtk_tree_view_column_get_widget(gtk_tree_view_get_column(GTK_TREE_VIEW(listview->theme_treeview), 0));
+    while (!GTK_IS_BUTTON(listview->theme_button)) {
+        listview->theme_button = gtk_widget_get_parent(listview->theme_button);
+    }
+    gtk_widget_hide(listview->theme_treeview);
 }
 
 gboolean
@@ -2663,39 +2623,21 @@ ddb_listview_header_motion_notify_event          (GtkWidget       *widget,
     }
     if (!ps->header_prepare && ps->header_dragging >= 0) {
         gdk_window_set_cursor (gtk_widget_get_window (widget), ps->cursor_drag);
-        DdbListviewColumn *c;
-        int i;
-        for (i = 0, c = ps->columns; i < ps->header_dragging && c; c = c->next, i++);
-        ps->col_movepos = ev_x - ps->header_dragpt[0] + ps->hscrollpos;
-        // find closest column to the left
-        int inspos = -1;
-        DdbListviewColumn *cc;
-        int x = 0;
-        int idx = 0;
-        int x1 = -1, x2 = -1;
-        for (cc = ps->columns; cc; cc = cc->next, idx++) {
-            if (x < ps->col_movepos && x + c->width > ps->col_movepos) {
-                inspos = idx;
-                x1 = x;
+        DdbListviewColumn *c = ps->columns;
+        for (int i = 0; c && i < ps->header_dragging; c = c->next, i++);
+        const int left = ev_x - ps->header_dragpt[0] + ps->hscrollpos;
+        const int right = left + c->width;
+        DdbListviewColumn *cc = ps->columns;
+        for (int xx = 0, ii = 0; cc; xx += cc->width, cc = cc->next, ii++) {
+            if (ps->header_dragging > ii && left < xx + cc->width/2 || ps->header_dragging < ii && right > xx + cc->width/2) {
+                ddb_listview_column_move (ps, c, ii);
+                ps->header_dragging = ii;
+                gtk_widget_queue_draw (ps->list);
+                break;
             }
-            else if (idx == ps->header_dragging) {
-                x2 = x;
-            }
-            x += cc->width;
         }
-        if (inspos >= 0 && inspos != ps->header_dragging) {
-            ddb_listview_column_move (ps, c, inspos);
-//            ps->binding->col_move (c, inspos);
-            ps->header_dragging = inspos;
-//            colhdr_anim_swap (ps, c1, c2, x1, x2);
-            // force redraw of everything
-//            ddb_listview_list_setup_hscroll (ps);
-            gtk_widget_queue_draw (ps->list);
-        }
-        else {
-            // only redraw that if not animating
-            gtk_widget_queue_draw (ps->header);
-        }
+        ps->col_movepos = left;
+        gtk_widget_queue_draw (ps->header);
     }
     else if (ps->header_sizing >= 0) {
         ps->last_header_motion_ev = event->time;
@@ -3075,8 +3017,8 @@ ddb_listview_is_scrolling (DdbListview *listview) {
 
 /////// column management code
 
-DdbListviewColumn * 
-ddb_listview_column_alloc (const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data) {
+DdbListviewColumn *
+ddb_listview_column_alloc (const char *title, int width, int align_right, minheight_cb minheight_cb, int color_override, GdkColor color, void *user_data) {
     DdbListviewColumn * c = malloc (sizeof (DdbListviewColumn));
     memset (c, 0, sizeof (DdbListviewColumn));
     c->title = strdup (title);
@@ -3084,7 +3026,7 @@ ddb_listview_column_alloc (const char *title, int width, int align_right, int mi
     c->align_right = align_right;
     c->color_override = color_override;
     c->color = color;
-    c->minheight = minheight;
+    c->minheight_cb = minheight_cb;
     c->user_data = user_data;
     return c;
 }
@@ -3101,8 +3043,8 @@ ddb_listview_column_get_count (DdbListview *listview) {
 }
 
 void
-ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data) {
-    DdbListviewColumn* c = ddb_listview_column_alloc (title, width, align_right, minheight, color_override, color, user_data);
+ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb minheight_cb, int color_override, GdkColor color, void *user_data) {
+    DdbListviewColumn* c = ddb_listview_column_alloc (title, width, align_right, minheight_cb, color_override, color, user_data);
     if (listview->col_autoresize) {
         c->fwidth = (float)c->width / listview->header_width;
     }
@@ -3124,8 +3066,8 @@ ddb_listview_column_append (DdbListview *listview, const char *title, int width,
 }
 
 void
-ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data) {
-    DdbListviewColumn *c = ddb_listview_column_alloc (title, width, align_right, minheight, color_override, color, user_data);
+ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb minheight_cb, int color_override, GdkColor color, void *user_data) {
+    DdbListviewColumn *c = ddb_listview_column_alloc (title, width, align_right, minheight_cb, color_override, color, user_data);
     if (listview->col_autoresize) {
         c->fwidth = (float)c->width / listview->header_width;
     }
@@ -3234,7 +3176,7 @@ ddb_listview_column_move (DdbListview *listview, DdbListviewColumn *which, int i
 }
 
 int
-ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, int *minheight, int *color_override, GdkColor *color, void **user_data) {
+ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb *minheight_cb, int *color_override, GdkColor *color, void **user_data) {
     DdbListviewColumn *c;
     int idx = 0;
     for (c = listview->columns; c; c = c->next, idx++) {
@@ -3242,7 +3184,7 @@ ddb_listview_column_get_info (DdbListview *listview, int col, const char **title
             *title = c->title;
             *width = c->width;
             *align_right = c->align_right;
-            *minheight = c->minheight;
+            if (minheight_cb) *minheight_cb = c->minheight_cb;
             *color_override = c->color_override;
             *color = c->color;
             *user_data = c->user_data;
@@ -3253,7 +3195,7 @@ ddb_listview_column_get_info (DdbListview *listview, int col, const char **title
 }
 
 int
-ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data) {
+ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb minheight_cb, int color_override, GdkColor color, void *user_data) {
     DdbListviewColumn *c;
     int idx = 0;
     for (c = listview->columns; c; c = c->next, idx++) {
@@ -3265,7 +3207,7 @@ ddb_listview_column_set_info (DdbListview *listview, int col, const char *title,
                 c->fwidth = (float)c->width / listview->header_width;
             }
             c->align_right = align_right;
-            c->minheight = minheight;
+            c->minheight_cb = minheight_cb;
             c->color_override = color_override;
             c->color = color;
             c->user_data = user_data;
@@ -3274,6 +3216,18 @@ ddb_listview_column_set_info (DdbListview *listview, int col, const char *title,
         }
     }
     return -1;
+}
+
+void
+ddb_listview_invalidate_album_art_columns (DdbListview *listview) {
+    GtkAllocation a;
+    gtk_widget_get_allocation (listview->list, &a);
+    int x = -listview->hscrollpos;
+    for (DdbListviewColumn *c = listview->columns; c && x < a.width; x += c->width, c = c->next) {
+        if (x + c->width > 0 && listview->binding->is_album_art_column(c->user_data)) {
+            gtk_widget_queue_draw_area(listview->list, x, 0, c->width, a.height);
+        }
+    }
 }
 /////// end of column management code
 
@@ -3295,28 +3249,33 @@ ddb_listview_free_groups (DdbListview *listview) {
     }
 }
 
+static int
+ddb_listview_min_group_height(DdbListviewColumn *columns) {
+    int min_height = 0;
+    for (DdbListviewColumn *c = columns; c; c = c->next) {
+        if (c->minheight_cb) {
+            const int col_min_height = c->minheight_cb(c->user_data, c->width);
+            if (min_height < col_min_height) {
+                min_height = col_min_height;
+            }
+        }
+    }
+    return min_height;
+}
+
 void
 ddb_listview_build_groups (DdbListview *listview) {
     deadbeef->pl_lock ();
     int old_height = listview->fullheight;
     listview->groups_build_idx = listview->binding->modification_idx ();
     ddb_listview_free_groups (listview);
-
-    listview->plt = deadbeef->plt_get_curr ();
-
     listview->fullheight = 0;
 
+    const int min_height = ddb_listview_min_group_height(listview->columns);
     DdbListviewGroup *grp = NULL;
-    char str[1024];
     char curr[1024];
-
-    int min_height= 0;
-    DdbListviewColumn *c;
-    for (c = listview->columns; c; c = c->next) {
-        if (c->minheight && c->width > min_height) {
-            min_height = c->width;
-        }
-    }
+    char str[1024];
+    listview->plt = deadbeef->plt_get_curr ();
 
     listview->grouptitle_height = listview->calculated_grouptitle_height;
     DdbListviewIter it = listview->binding->head ();
@@ -3383,14 +3342,7 @@ ddb_listview_resize_groups (DdbListview *listview) {
     int grp_height_old = 0;
     listview->fullheight = 0;
 
-    int min_height= 0;
-    DdbListviewColumn *c;
-    for (c = listview->columns; c; c = c->next) {
-        if (c->minheight && c->width > min_height) {
-            min_height = c->width;
-        }
-    }
-
+    const int min_height = ddb_listview_min_group_height(listview->columns);
     DdbListviewGroup *grp = listview->groups;
     while (grp) {
         grp->height = listview->grouptitle_height + grp->num_items * listview->rowheight;
@@ -3410,6 +3362,9 @@ ddb_listview_resize_groups (DdbListview *listview) {
 
 void
 ddb_listview_set_vscroll (DdbListview *listview, int scroll) {
+    if (scroll == 0 && listview->scrollpos == -1) {
+        listview->scrollpos = 0;
+    }
     GtkAdjustment *adj = gtk_range_get_adjustment (GTK_RANGE (listview->scrollbar));
     gtk_range_set_value (GTK_RANGE (listview->scrollbar), scroll);
 }
@@ -3436,4 +3391,3 @@ ddb_listview_list_key_press_event (GtkWidget *widget, GdkEventKey *event, gpoint
     }
     return TRUE;
 }
-

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -127,9 +127,6 @@ struct _DdbListview {
     GtkWidget *header;
     GtkWidget *scrollbar;
     GtkWidget *hscrollbar;
-    GtkWidget *theme_treeview;
-    GtkWidget *theme_button;
-    GtkStyle *button_style;
 
     int totalwidth; // width of listview, including invisible (scrollable) part
     const char *title; // unique id, used for config writing, etc

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -60,7 +60,7 @@ struct _DdbListviewGroup {
     struct _DdbListviewGroup *next;
 };
 
-typedef int (*minheight_cb) (void *user_data, const int width);
+typedef int (*minheight_cb_t) (void *user_data, int width);
 typedef struct _DdbListviewGroup DdbListviewGroup;
 //typedef void * DdbListviewColIter;
 
@@ -205,7 +205,7 @@ struct _DdbListview {
 };
 
 struct _DdbListviewClass {
-  GtkTableClass parent_class;
+    GtkTableClass parent_class;
 };
 
 GType ddb_listview_get_type(void);
@@ -237,15 +237,15 @@ ddb_listview_is_scrolling (DdbListview *listview);
 int
 ddb_listview_column_get_count (DdbListview *listview);
 void
-ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
 void
-ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
 void
 ddb_listview_column_remove (DdbListview *listview, int idx);
 int
-ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb *, int *color_override, GdkColor *color, void **user_data);
+ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *color_override, GdkColor *color, void **user_data);
 int
-ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
 
 void
 ddb_listview_show_header (DdbListview *listview, int show);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -45,12 +45,6 @@ G_BEGIN_DECLS
 #define DDB_IS_LISTVIEW_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE ((obj), DDB_TYPE_LISTVIEW))
 #define DDB_LISTVIEW_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), DDB_TYPE_LISTVIEW, DdbListviewClass))
 
-typedef struct {
-    int id; // predefined col type
-    char *format;
-    char *bytecode;
-} col_info_t;
-
 typedef struct _DdbListview DdbListview;
 typedef struct _DdbListviewClass DdbListviewClass;
 
@@ -66,6 +60,7 @@ struct _DdbListviewGroup {
     struct _DdbListviewGroup *next;
 };
 
+typedef int (*minheight_cb) (void *user_data, const int width);
 typedef struct _DdbListviewGroup DdbListviewGroup;
 //typedef void * DdbListviewColIter;
 
@@ -93,23 +88,26 @@ typedef struct {
 
     int (*get_group) (DdbListview *listview, DdbListviewIter it, char *str, int size);
 
-    // drag-n-drop
     void (*drag_n_drop) (DdbListviewIter before, DdbPlaylistHandle playlist_from, uint32_t *indices, int length, int copy);
     void (*external_drag_n_drop) (DdbListviewIter before, char *mem, int length);
 
-    // callbacks
     void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int pl_iter, int x, int y, int width, int height);
-    void (*draw_album_art) (DdbListview *listview, cairo_t *drawable, DdbListviewIter group_iter, int column, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+    void (*draw_album_art) (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
     void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int column, int pl_iter, int x, int y, int width, int height);
+
+    // cols
+    int (*is_album_art_column) (void *user_data);
+    void (*columns_changed) (DdbListview *listview);
+    void (*col_sort) (int col, int sort_order, void *user_data);
+    void (*col_free_user_data) (void *user_data);
+
+    // callbacks
     void (*list_context_menu) (DdbListview *listview, DdbListviewIter iter, int idx);
     void (*header_context_menu) (DdbListview *listview, int col);
     void (*handle_doubleclick) (DdbListview *listview, DdbListviewIter iter, int idx);
     void (*selection_changed) (DdbListview *listview, DdbListviewIter it, int idx);
     void (*delete_selected) (void);
     void (*groups_changed) (DdbListview *listview, const char *format);
-    void (*columns_changed) (DdbListview *listview);
-    void (*col_sort) (int col, int sort_order, void *user_data);
-    void (*col_free_user_data) (void *user_data);
     void (*vscroll_changed) (int pos);
     void (*cursor_changed) (int pos);
     int (*modification_idx) (void);
@@ -129,6 +127,9 @@ struct _DdbListview {
     GtkWidget *header;
     GtkWidget *scrollbar;
     GtkWidget *hscrollbar;
+    GtkWidget *theme_treeview;
+    GtkWidget *theme_button;
+    GtkStyle *button_style;
 
     int totalwidth; // width of listview, including invisible (scrollable) part
     const char *title; // unique id, used for config writing, etc
@@ -193,11 +194,6 @@ struct _DdbListview {
     drawctx_t grpctx;
     drawctx_t hdrctx;
 
-    // cover art size
-    int cover_size;
-    int new_cover_size;
-    guint cover_refresh_timeout_id;
-
     // group format string that's supposed to get parsed by tf
     char *group_format;
     // tf bytecode for group title
@@ -241,15 +237,15 @@ ddb_listview_is_scrolling (DdbListview *listview);
 int
 ddb_listview_column_get_count (DdbListview *listview);
 void
-ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
 void
-ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
 void
 ddb_listview_column_remove (DdbListview *listview, int idx);
 int
-ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, int *minheight, int *color_override, GdkColor *color, void **user_data);
+ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb *, int *color_override, GdkColor *color, void **user_data);
 int
-ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, int minheight, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb, int color_override, GdkColor color, void *user_data);
 
 void
 ddb_listview_show_header (DdbListview *listview, int show);
@@ -307,6 +303,9 @@ ddb_listview_list_drag_end                   (GtkWidget       *widget,
                                         gpointer         user_data);
 
 void
+ddb_listview_invalidate_album_art_columns (DdbListview *listview);
+
+void
 ddb_listview_clear_sort (DdbListview *listview);
 
 void
@@ -317,12 +316,6 @@ ddb_listview_get_row_pos (DdbListview *listview, int row_idx);
 
 void
 ddb_listview_groupcheck (DdbListview *listview);
-
-int
-ddb_listview_is_album_art_column (DdbListview *listview, int x);
-
-int
-ddb_listview_is_album_art_column_idx (DdbListview *listview, int cidx);
 
 void
 ddb_listview_update_fonts (DdbListview *ps);

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -88,7 +88,7 @@ int main_get_idx (DdbListviewIter it) {
     DB_playItem_t *c = deadbeef->pl_get_first (PL_MAIN);
     int idx = 0;
     while (c && c != it) {
-        DB_playItem_t *next = deadbeef->pl_get_next (c, PL_MAIN); 
+        DB_playItem_t *next = deadbeef->pl_get_next (c, PL_MAIN);
         deadbeef->pl_item_unref (c);
         c = next;
         idx++;
@@ -205,19 +205,6 @@ main_columns_changed (DdbListview *listview) {
     }
 }
 
-void main_col_free_user_data (void *data) {
-    if (data) {
-        col_info_t *inf = data;
-        if (inf->format) {
-            free (inf->format);
-        }
-        if (inf->bytecode) {
-            free (inf->bytecode);
-        }
-        free (data);
-    }
-}
-
 void
 main_vscroll_changed (int pos) {
     coverart_reset_queue ();
@@ -230,7 +217,7 @@ main_vscroll_changed (int pos) {
 
 void
 main_header_context_menu (DdbListview *ps, int column) {
-    GtkWidget *menu = create_headermenu (1);
+    GtkWidget *menu = create_headermenu (ps, 1);
     set_last_playlist_cm (ps); // playlist ptr for context menu
     set_active_column_cm (column);
     gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, ps, 3, gtk_get_current_event_time());
@@ -266,9 +253,10 @@ DdbListviewBinding main_binding = {
     .draw_group_title = pl_common_draw_group_title,
 
     // columns
+    .is_album_art_column = is_album_art_column,
     .col_sort = main_col_sort,
     .columns_changed = main_columns_changed,
-    .col_free_user_data = main_col_free_user_data,
+    .col_free_user_data = pl_common_free_col_info,
 
     // callbacks
     .handle_doubleclick = main_handle_doubleclick,

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -288,25 +288,6 @@ cover_draw_exact (DB_playItem_t *it, const int x, const int min_y, const int max
 
 void
 draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height) {
-    if (gtkui_override_listview_colors()) {
-        GdkColor clr;
-        gtkui_get_listview_even_row_color(&clr);
-        cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
-        cairo_rectangle(cr, x, y, width, height);
-        cairo_fill(cr);
-    }
-    else {
-#if GTK_CHECK_VERSION(3,0,0)
-        GtkStyleContext *context = gtk_widget_get_style_context(listview->theme_treeview);
-        gtk_style_context_save(context);
-        gtk_style_context_add_region(context, GTK_STYLE_REGION_ROW, GTK_REGION_EVEN);
-        gtk_render_background(context, cr, x, y, width, height);
-        gtk_style_context_restore(context);
-#else
-        gtk_paint_flat_box(gtk_widget_get_style(listview->theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, listview->theme_treeview, "cell_even_ruled", x, y, width, height);
-#endif
-    }
-
     const int art_width = width - ART_PADDING_HORZ * 2;
     const int art_height = height - ART_PADDING_VERT * 2;
     if (art_width < 8 || art_height < 8 || !it) {

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -47,8 +47,6 @@
 #define DISABLE_CUSTOM_TITLE
 
 // playlist theming
-GtkWidget *theme_button;
-GtkWidget *theme_treeview;
 static GdkPixbuf *play16_pixbuf;
 static GdkPixbuf *pause16_pixbuf;
 static GdkPixbuf *buffering16_pixbuf;
@@ -61,30 +59,61 @@ pl_common_init(void)
     play16_pixbuf = create_pixbuf("play_16.png");
     pause16_pixbuf = create_pixbuf("pause_16.png");
     buffering16_pixbuf = create_pixbuf("buffering_16.png");
-
-    gtkui_groups_pinned = deadbeef->conf_get_int ("playlist.pin.groups", 0);
-
-    theme_treeview = gtk_tree_view_new ();
-    gtk_widget_show (theme_treeview);
-    gtk_widget_set_can_focus (theme_treeview, FALSE);
-    GtkWidget *vbox1 = lookup_widget (mainwin, "vbox1");
-    gtk_box_pack_start (GTK_BOX (vbox1), theme_treeview, FALSE, FALSE, 0);
-    gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (theme_treeview), TRUE);
-
-    theme_button = mainwin;//lookup_widget (mainwin, "stopbtn");
 }
 
 void
 pl_common_free (void)
 {
-    if (theme_treeview) {
-        gtk_widget_destroy (theme_treeview);
-        theme_treeview = NULL;
-    }
-
     g_object_unref(play16_pixbuf);
     g_object_unref(pause16_pixbuf);
     g_object_unref(buffering16_pixbuf);
+}
+
+static col_info_t *
+create_col_info (DdbListview *listview, int id) {
+    col_info_t *info = malloc(sizeof(col_info_t));
+    memset(info, '\0', sizeof(col_info_t));
+    info->id = id;
+    info->cover_size = -1;
+    info->new_cover_size = -1;
+    info->listview = listview;
+    return info;
+}
+
+static gboolean
+coverart_release_cb (void *user_data) {
+    col_info_t *info = user_data;
+    g_object_unref(info->listview->list);
+    free(user_data);
+    return FALSE;
+}
+
+static void
+coverart_release (void *user_data) {
+    g_idle_add(coverart_release_cb, user_data);
+}
+
+void
+pl_common_free_col_info (void *data) {
+    if (!data) {
+        return;
+    }
+
+    col_info_t *info = data;
+    if (info->format) {
+        free (info->format);
+    }
+    if (info->bytecode) {
+        free (info->bytecode);
+    }
+    if (is_album_art_column(info)) {
+        g_object_ref(info->listview->list);
+        queue_cover_callback(coverart_release, info);
+        if (info->cover_load_timeout_id) {
+            g_source_remove(info->cover_load_timeout_id);
+            info->cover_load_timeout_id = 0;
+        }
+    }
 }
 
 #define COL_CONF_BUFFER_SIZE 10000
@@ -102,10 +131,9 @@ rewrite_column_config (DdbListview *listview, const char *name) {
         int width;
         int align;
         col_info_t *info;
-        int minheight;
         int color_override;
         GdkColor color;
-        ddb_listview_column_get_info (listview, i, &title, &width, &align, &minheight, &color_override, &color, (void **)&info);
+        ddb_listview_column_get_info (listview, i, &title, &width, &align, NULL, &color_override, &color, (void **)&info);
 
         char *esctitle = parser_escape_string (title);
         char *escformat = info->format ? parser_escape_string (info->format) : NULL;
@@ -128,13 +156,6 @@ rewrite_column_config (DdbListview *listview, const char *name) {
 }
 
 static gboolean
-redraw_playlist_cb (gpointer user_data) {
-    DDB_LISTVIEW(user_data)->cover_size = DDB_LISTVIEW(user_data)->new_cover_size;
-    gtk_widget_queue_draw (GTK_WIDGET(user_data));
-    return FALSE;
-}
-
-static gboolean
 tf_redraw_cb (gpointer user_data) {
     DdbListview *lv = user_data;
 
@@ -149,193 +170,167 @@ tf_redraw_cb (gpointer user_data) {
     return FALSE;
 }
 
-static void
-redraw_playlist (void *user_data) {
-    g_idle_add (redraw_playlist_cb, user_data);
-}
-
-static gboolean
-redraw_playlist_single_cb (gpointer user_data) {
-    gtk_widget_queue_draw (GTK_WIDGET(user_data));
-    g_object_unref (GTK_WIDGET (user_data));
-    return FALSE;
-}
-
-static void
-redraw_playlist_single (void *user_data) {
-    g_object_ref (GTK_WIDGET (user_data));
-    g_idle_add (redraw_playlist_single_cb, user_data);
-}
-
 #define ART_PADDING_HORZ 8
 #define ART_PADDING_VERT 0
 
-static gboolean
-deferred_cover_load_cb (void *ctx) {
-    DdbListview *lv = ctx;
-    lv->cover_refresh_timeout_id = 0;
-    deadbeef->pl_lock ();
-    ddb_listview_groupcheck (lv);
-    // find 1st group
-    DdbListviewGroup *grp = lv->groups;
-    int idx = 0;
-    int abs_idx = 0;
-    int grp_y = 0;
-    while (grp && grp_y + grp->height < lv->scrollpos) {
-        grp_y += grp->height;
-        idx += grp->num_items + 1;
-        abs_idx += grp->num_items;
-        grp = grp->next;
+static int
+min_group_height(void *user_data, const int width) {
+    col_info_t *info = (col_info_t *)user_data;
+    if (info->id == DB_COLUMN_ALBUM_ART) {
+        return width - 2*ART_PADDING_HORZ + 2*ART_PADDING_VERT;
     }
+    return 0;
+}
+
+///// cover art display
+int
+is_album_art_column (void *user_data) {
+    col_info_t *info = (col_info_t *)user_data;
+    return info->id == DB_COLUMN_ALBUM_ART;
+}
+
+static GdkPixbuf *
+get_cover_art (DB_playItem_t *it, const int width, const int height, void (*callback)(void *), void *user_data) {
+    deadbeef->pl_lock();
+    const char *uri = deadbeef->pl_find_meta(it, ":URI");
+    const char *album = deadbeef->pl_find_meta(it, "album");
+    const char *artist = deadbeef->pl_find_meta(it, "artist");
+    if (!album || !*album) {
+        album = deadbeef->pl_find_meta(it, "title");
+    }
+    GdkPixbuf *pixbuf = get_cover_art_thumb_by_size(uri, artist, album, width, height, callback, user_data);
+    deadbeef->pl_unlock();
+    return pixbuf;
+}
+
+static gboolean
+cover_invalidate_cb (void *user_data) {
+    col_info_t *info = user_data;
+    info->cover_size = info->new_cover_size;
+    ddb_listview_invalidate_album_art_columns(info->listview);
+    return FALSE;
+}
+
+static void
+cover_invalidate (void *user_data) {
+    g_idle_add(cover_invalidate_cb, user_data);
+}
+
+static gboolean
+cover_load (void *user_data) {
+    col_info_t *info = user_data;
+    info->cover_load_timeout_id = 0;
+
+    ddb_listview_groupcheck(info->listview);
+    DdbListviewGroup *group = info->listview->groups;
+    int group_y = 0;
+    while (group && group_y + group->height < info->listview->scrollpos) {
+        group_y += group->height;
+        group = group->next;
+    }
+
     GtkAllocation a;
-    gtk_widget_get_allocation (GTK_WIDGET (lv), &a);
-    while (grp && grp_y < a.height + lv->scrollpos) {
-        // render title
-        DdbListviewIter group_it = grp->head;
-        int grpheight = grp->height;
-        if (grp_y >= a.height + lv->scrollpos) {
-            break;
-        }
-        const char *album = deadbeef->pl_find_meta (group_it, "album");
-        const char *artist = deadbeef->pl_find_meta (group_it, "artist");
-        if (!album || !*album) {
-            album = deadbeef->pl_find_meta (group_it, "title");
+    gtk_widget_get_allocation(info->listview->list, &a);
+    const int end_pos = info->listview->scrollpos + a.height;
+    while (group && group_y < end_pos) {
+        GdkPixbuf *pixbuf = get_cover_art(group->head, info->new_cover_size, info->new_cover_size, NULL, NULL);
+        if (pixbuf) {
+            g_object_unref(pixbuf);
         }
 
-        grp_y += grpheight;
-        grp = grp->next;
-        int last = 0;
-        if (!grp || grp_y >= a.height + lv->scrollpos) {
-            last = 1;
-        }
-        GdkPixbuf *pixbuf = get_cover_art_thumb (deadbeef->pl_find_meta (((DB_playItem_t *)group_it), ":URI"), artist, album, lv->new_cover_size, NULL, NULL);
-        if (last) {
-            queue_cover_callback (redraw_playlist, lv);
-        }
-        if (pixbuf) {
-            g_object_unref (pixbuf);
-        }
+        group_y += group->height;
+        group = group->next;
     }
-    deadbeef->pl_unlock ();
+    queue_cover_callback(cover_invalidate, info);
 
     return FALSE;
 }
 
+static void
+cover_draw_cairo (GdkPixbuf *pixbuf, const int x, const int min_y, const int max_y, const int width, const int height, cairo_t *cr, const int filter) {
+    const int pw = gdk_pixbuf_get_width(pixbuf);
+    const int ph = gdk_pixbuf_get_height(pixbuf);
+    const int real_y = min(min_y, max_y - ph);
+    cairo_save(cr);
+    cairo_rectangle(cr, x, min_y, width, max_y - min_y);
+    cairo_translate (cr, x, real_y);
+    if (pw > width || ph > height || pw < width && ph < height) {
+        const double scale = min(width/(double)pw, height/(double)ph);
+        cairo_translate(cr, (width - width*scale)/2., min(min_y, max_y - ph*scale) - real_y);
+        cairo_scale(cr, scale, scale);
+        cairo_pattern_set_filter(cairo_get_source(cr), filter);
+    }
+    gdk_cairo_set_source_pixbuf(cr, pixbuf, (width - pw)/2., 0);
+    cairo_fill(cr);
+    cairo_restore(cr);
+}
+
+static void
+cover_draw_anything (DB_playItem_t *it, const int x, const int min_y, const int max_y, const int width, const int height, cairo_t *cr) {
+    GdkPixbuf *pixbuf = get_cover_art(it, -1, -1, NULL, NULL);
+    if (pixbuf) {
+        cover_draw_cairo(pixbuf, x, min_y, max_y, width, height, cr, CAIRO_FILTER_FAST);
+        g_object_unref(pixbuf);
+    }
+}
+
+static void
+cover_draw_exact (DB_playItem_t *it, const int x, const int min_y, const int max_y, const int width, const int height, cairo_t *cr, void *user_data) {
+    GdkPixbuf *pixbuf = get_cover_art(it, width, width, cover_invalidate, user_data);
+    if (pixbuf) {
+        cover_draw_cairo(pixbuf, x, min_y, max_y, width, height, cr, CAIRO_FILTER_BEST);
+        g_object_unref(pixbuf);
+    }
+    else {
+        cover_draw_anything(it, x, min_y, max_y, width, height, cr);
+    }
+}
+
 void
-draw_album_art (DdbListview *listview, cairo_t *cr, DdbListviewIter group_it, int column, int group_pinned, int grp_next_y, int x, int y, int width, int height) {
-    const char *ctitle;
-    int cwidth;
-    int calign_right;
-    col_info_t *cinf;
-    int minheight;
-    int color_override;
-    GdkColor fg_clr;
-    int res = ddb_listview_column_get_info (listview, column, &ctitle, &cwidth, &calign_right, &minheight, &color_override, &fg_clr, (void **)&cinf);
-    if (res == -1) {
+draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height) {
+    if (gtkui_override_listview_colors()) {
+        GdkColor clr;
+        gtkui_get_listview_even_row_color(&clr);
+        cairo_set_source_rgb(cr, clr.red/65535., clr.green/65535., clr.blue/65535.);
+        cairo_rectangle(cr, x, y, width, height);
+        cairo_fill(cr);
+    }
+    else {
+#if GTK_CHECK_VERSION(3,0,0)
+        GtkStyleContext *context = gtk_widget_get_style_context(listview->theme_treeview);
+        gtk_style_context_save(context);
+        gtk_style_context_add_region(context, GTK_STYLE_REGION_ROW, GTK_REGION_EVEN);
+        gtk_render_background(context, cr, x, y, width, height);
+        gtk_style_context_restore(context);
+#else
+        gtk_paint_flat_box(gtk_widget_get_style(listview->theme_treeview), gtk_widget_get_window(listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, NULL, listview->theme_treeview, "cell_even_ruled", x, y, width, height);
+#endif
+    }
+
+    const int art_width = width - ART_PADDING_HORZ * 2;
+    const int art_height = height - ART_PADDING_VERT * 2;
+    if (art_width < 8 || art_height < 8 || !it) {
         return;
     }
 
-    DB_playItem_t *playing_track = deadbeef->streamer_get_playing_track ();
-    int theming = !gtkui_override_listview_colors ();
-
-    if (cinf->id == DB_COLUMN_ALBUM_ART) {
-        if (theming) {
-#if GTK_CHECK_VERSION(3,0,0)
-            cairo_save (cr);
-            cairo_rectangle (cr, x, y, width, MAX (height,minheight));
-            cairo_clip (cr);
-            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), cr, GTK_STATE_NORMAL, GTK_SHADOW_NONE, theme_treeview, "cell_even_ruled", x-1, y, width+2, MAX (height,minheight));
-            cairo_restore (cr);
-#else
-            GdkRectangle clip = {
-                .x = x,
-                .y = y,
-                .width = width,
-                .height = MAX (height,minheight),
-            };
-            gtk_paint_flat_box (gtk_widget_get_style (theme_treeview), gtk_widget_get_window (listview->list), GTK_STATE_NORMAL, GTK_SHADOW_NONE, &clip, theme_treeview, "cell_even_ruled", x-1, y, width+2, height);
-#endif
-        }
-        else {
-            GdkColor clr;
-            gtkui_get_listview_even_row_color (&clr);
-            cairo_set_source_rgb (cr, clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f);
-            cairo_rectangle (cr, x, y, width, height);
-            cairo_fill (cr);
-        }
-        int real_art_width = width - ART_PADDING_HORZ * 2;
-        if (real_art_width > 7 && group_it) {
-            const char *album = deadbeef->pl_find_meta (group_it, "album");
-            const char *artist = deadbeef->pl_find_meta (group_it, "artist");
-            if (!album || !*album) {
-                album = deadbeef->pl_find_meta (group_it, "title");
-            }
-            if (listview->new_cover_size != real_art_width) {
-                listview->new_cover_size = real_art_width;
-                if (listview->cover_refresh_timeout_id) {
-                    g_source_remove (listview->cover_refresh_timeout_id);
-                    listview->cover_refresh_timeout_id = 0;
-                }
-                if (listview->cover_size == -1) {
-                    listview->cover_size = real_art_width;
-                }
-                else {
-                    if (!listview->cover_refresh_timeout_id) {
-                        listview->cover_refresh_timeout_id = g_timeout_add (1000, deferred_cover_load_cb, listview);
-                    }
-                }
-            }
-
-            // destination coordinates and sizes
-            int art_x = x + ART_PADDING_HORZ;
-            int art_y = y + ART_PADDING_VERT;
-            int art_w = listview->cover_size;
-            int art_h = height;
-
-            GdkPixbuf *pixbuf = get_cover_art_thumb (deadbeef->pl_find_meta (((DB_playItem_t *)group_it), ":URI"), artist, album, real_art_width == art_w ? art_w : -1, redraw_playlist_single, listview);
-            if (pixbuf) {
-                art_w = gdk_pixbuf_get_width (pixbuf);
-                art_h = gdk_pixbuf_get_height (pixbuf);
-
-                int draw_pinned = (y - listview->grouptitle_height < real_art_width && group_pinned == 1 && gtkui_groups_pinned) ? 1 : 0;
-
-                if (art_y > -(real_art_width + listview->grouptitle_height) || draw_pinned) {
-                    float art_scale = real_art_width;
-                    if (art_w < art_h) {
-                        art_scale /= (float)art_h;
-                    }
-                    else {
-                        art_scale /= (float)art_w;
-                    }
-
-                    art_w *= art_scale;
-                    art_h *= art_scale;
-
-                    cairo_save (cr);
-                    if (draw_pinned) {
-                        if (grp_next_y <= art_h + listview->grouptitle_height + ART_PADDING_VERT) {
-                            cairo_translate (cr, art_x, grp_next_y - art_h);
-                        }
-                        else {
-                            cairo_translate (cr, art_x, listview->grouptitle_height + ART_PADDING_VERT);
-                        }
-                    }
-                    else {
-                        cairo_translate (cr, art_x, art_y);
-                    }
-                    cairo_rectangle (cr, 0, 0, art_w, art_h);
-                    cairo_scale (cr, art_scale, art_scale);
-                    gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
-                    cairo_pattern_set_filter (cairo_get_source(cr), gtkui_is_default_pixbuf (pixbuf) ? CAIRO_FILTER_BEST : CAIRO_FILTER_FAST);
-                    cairo_fill (cr);
-                    cairo_restore (cr);
-                }
-                g_object_unref (pixbuf);
-            }
-        }
+    col_info_t *info = user_data;
+    if (info->new_cover_size == -1) {
+        info->new_cover_size = art_width;
+        info->cover_size = art_width;
     }
-    if (playing_track) {
-        deadbeef->pl_item_unref (playing_track);
+
+    const int art_x = x + ART_PADDING_HORZ;
+    const int min_y = (pinned == 1 && gtkui_groups_pinned ? listview->grouptitle_height : y) + ART_PADDING_VERT;
+    if (info->cover_size == art_width) {
+        cover_draw_exact(it, art_x, min_y, next_y, art_width, art_height, cr, info);
+    }
+    else {
+        cover_draw_anything(it, art_x, min_y, next_y, art_width, art_height, cr);
+        if (info->cover_load_timeout_id) {
+            g_source_remove(info->cover_load_timeout_id);
+        }
+        info->cover_load_timeout_id = g_timeout_add(1000, cover_load, info);
+        info->new_cover_size = art_width;
     }
 }
 
@@ -345,10 +340,9 @@ draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int co
     int cwidth;
     int calign_right;
     col_info_t *cinf;
-    int minheight;
     int color_override;
     GdkColor fg_clr;
-    int res = ddb_listview_column_get_info (listview, column, &ctitle, &cwidth, &calign_right, &minheight, &color_override, &fg_clr, (void **)&cinf);
+    int res = ddb_listview_column_get_info (listview, column, &ctitle, &cwidth, &calign_right, NULL, &color_override, &fg_clr, (void **)&cinf);
     if (res == -1) {
         return;
     }
@@ -425,14 +419,14 @@ draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int co
         GdkColor *color = NULL;
         if (theming) {
             if (deadbeef->pl_is_selected (it)) {
-                color = &gtk_widget_get_style (theme_treeview)->text[GTK_STATE_SELECTED];
+                color = &gtk_widget_get_style (listview->theme_treeview)->text[GTK_STATE_SELECTED];
             }
             else {
                 if (color_override) {
                     color = &fg_clr;
                 }
                 else {
-                    color = &gtk_widget_get_style (theme_treeview)->text[GTK_STATE_NORMAL];
+                    color = &gtk_widget_get_style (listview->theme_treeview)->text[GTK_STATE_NORMAL];
                 }
             }
         }
@@ -486,7 +480,7 @@ main_add_to_playback_queue_activate     (GtkMenuItem     *menuitem,
     DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
     while (it) {
         if (deadbeef->pl_is_selected (it)) {
-            deadbeef->pl_playqueue_push (it);
+            deadbeef->playqueue_push (it);
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
@@ -503,7 +497,7 @@ main_remove_from_playback_queue_activate
     DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
     while (it) {
         if (deadbeef->pl_is_selected (it)) {
-            deadbeef->pl_playqueue_remove (it);
+            deadbeef->playqueue_remove (it);
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
@@ -740,7 +734,7 @@ popup_menu_position_func (GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gp
 void
 list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
     clicked_idx = deadbeef->pl_get_idx_of (it);
-    int inqueue = deadbeef->pl_playqueue_test (it);
+    int inqueue = deadbeef->playqueue_test (it);
     GtkWidget *playlist_menu;
     GtkWidget *add_to_playback_queue1;
     GtkWidget *remove_from_playback_queue1;
@@ -1147,14 +1141,12 @@ load_column_config (DdbListview *listview, const char *key) {
             }
         }
 
-        col_info_t *inf = malloc (sizeof (col_info_t));
-        memset (inf, 0, sizeof (col_info_t));
-        inf->id = iid;
+        col_info_t *inf = create_col_info(listview, iid);
         if (sformat) {
             inf->format = strdup (sformat);
             inf->bytecode = deadbeef->tf_compile (inf->format);
         }
-        ddb_listview_column_append (listview, stitle, iwidth, ialign, inf->id == DB_COLUMN_ALBUM_ART ? iwidth : 0, icolor_override, gdkcolor, inf);
+        ddb_listview_column_append (listview, stitle, iwidth, ialign, inf->id == DB_COLUMN_ALBUM_ART ? min_group_height : NULL, icolor_override, gdkcolor, inf);
     }
     json_decref(root);
     return 0;
@@ -1232,8 +1224,7 @@ error:
 
 parse_end: ;
 
-    col_info_t *inf = malloc (sizeof (col_info_t));
-    memset (inf, 0, sizeof (col_info_t));
+    col_info_t *inf = create_col_info(listview, -1);
 
     enum {
         DB_COLUMN_ARTIST_ALBUM = 2,
@@ -1244,7 +1235,6 @@ parse_end: ;
         DB_COLUMN_TRACK = 7,
     };
 
-    inf->id = -1;
     // convert IDs from pre-0.4
     switch (id) {
     case DB_COLUMN_ARTIST_ALBUM:
@@ -1353,13 +1343,11 @@ on_add_column_activate                 (GtkMenuItem     *menuitem,
         GdkColor clr;
         gtk_color_button_get_color (GTK_COLOR_BUTTON (lookup_widget (dlg, "color")), &clr);
 
-        col_info_t *inf = malloc (sizeof (col_info_t));
-        memset (inf, 0, sizeof (col_info_t));
-
+        col_info_t *inf = create_col_info(user_data, 0);
         init_column (inf, sel, format);
 
         int align = gtk_combo_box_get_active (GTK_COMBO_BOX (lookup_widget (dlg, "align")));
-        ddb_listview_column_insert (last_playlist, active_column, title, 100, align, inf->id == DB_COLUMN_ALBUM_ART ? 100 : 0, clr_override, clr, inf);
+        ddb_listview_column_insert (last_playlist, active_column, title, 100, align, inf->id == DB_COLUMN_ALBUM_ART ? min_group_height : NULL, clr_override, clr, inf);
         ddb_listview_refresh (last_playlist, DDB_LIST_CHANGED | DDB_REFRESH_COLUMNS | DDB_REFRESH_LIST | DDB_REFRESH_HSCROLL);
     }
     gtk_widget_destroy (dlg);
@@ -1380,10 +1368,9 @@ on_edit_column_activate                (GtkMenuItem     *menuitem,
     int width;
     int align_right;
     col_info_t *inf;
-    int minheight;
     int color_override;
     GdkColor color;
-    int res = ddb_listview_column_get_info (last_playlist, active_column, &title, &width, &align_right, &minheight, &color_override, &color, (void **)&inf);
+    int res = ddb_listview_column_get_info (last_playlist, active_column, &title, &width, &align_right, NULL, &color_override, &color, (void **)&inf);
     if (res == -1) {
         trace ("attempted to edit non-existing column\n");
         return;
@@ -1392,25 +1379,25 @@ on_edit_column_activate                (GtkMenuItem     *menuitem,
     int idx = 10;
     if (inf->id == -1) {
         if (inf->format) {
-            if (!strcmp (inf->format, "%a - %b")) {
+            if (!strcmp (inf->format, "%artist% - %album%")) {
                 idx = 3;
             }
-            else if (!strcmp (inf->format, "%a")) {
+            else if (!strcmp (inf->format, "%artist%")) {
                 idx = 4;
             }
-            else if (!strcmp (inf->format, "%b")) {
+            else if (!strcmp (inf->format, "%album%")) {
                 idx = 5;
             }
-            else if (!strcmp (inf->format, "%t")) {
+            else if (!strcmp (inf->format, "%title%")) {
                 idx = 6;
             }
-            else if (!strcmp (inf->format, "%l")) {
+            else if (!strcmp (inf->format, "%length%")) {
                 idx = 7;
             }
-            else if (!strcmp (inf->format, "%n")) {
+            else if (!strcmp (inf->format, "%track number%")) {
                 idx = 8;
             }
-            else if (!strcmp (inf->format, "%B")) {
+            else if (!strcmp (inf->format, "%album artist%")) {
                 idx = 9;
             }
         }
@@ -1443,7 +1430,7 @@ on_edit_column_activate                (GtkMenuItem     *menuitem,
         gtk_color_button_get_color (GTK_COLOR_BUTTON (lookup_widget (dlg, "color")), &clr);
 
         init_column (inf, id, format);
-        ddb_listview_column_set_info (last_playlist, active_column, title, width, align, inf->id == DB_COLUMN_ALBUM_ART ? width : 0, clr_override, clr, inf);
+        ddb_listview_column_set_info (last_playlist, active_column, title, width, align, inf->id == DB_COLUMN_ALBUM_ART ? min_group_height : NULL, clr_override, clr, inf);
 
         ddb_listview_refresh (last_playlist, DDB_LIST_CHANGED | DDB_REFRESH_COLUMNS | DDB_REFRESH_LIST);
     }
@@ -1463,7 +1450,7 @@ on_remove_column_activate              (GtkMenuItem     *menuitem,
 }
 
 GtkWidget*
-create_headermenu (int groupby)
+create_headermenu (DdbListview *listview, int groupby)
 {
   GtkWidget *headermenu;
   GtkWidget *add_column;
@@ -1549,13 +1536,13 @@ create_headermenu (int groupby)
 
   g_signal_connect ((gpointer) add_column, "activate",
                     G_CALLBACK (on_add_column_activate),
-                    NULL);
+                    listview);
   g_signal_connect ((gpointer) edit_column, "activate",
                     G_CALLBACK (on_edit_column_activate),
-                    NULL);
+                    listview);
   g_signal_connect ((gpointer) remove_column, "activate",
                     G_CALLBACK (on_remove_column_activate),
-                    NULL);
+                    listview);
 
   return headermenu;
 }
@@ -1565,13 +1552,11 @@ add_column_helper (DdbListview *listview, const char *title, int width, int id, 
     if (!format) {
         format = "";
     }
-    col_info_t *inf = malloc (sizeof (col_info_t));
-    memset (inf, 0, sizeof (col_info_t));
-    inf->id = id;
+    col_info_t *inf = create_col_info(listview, id);
     inf->format = strdup (format);
     inf->bytecode = deadbeef->tf_compile (inf->format);
     GdkColor color = { 0, 0, 0, 0 };
-    ddb_listview_column_append (listview, title, width, align_right, inf->id == DB_COLUMN_ALBUM_ART ? width : 0, 0, color, inf);
+    ddb_listview_column_append (listview, title, width, align_right, inf->id == DB_COLUMN_ALBUM_ART ? min_group_height : NULL, 0, color, inf);
 }
 
 int
@@ -1633,14 +1618,14 @@ pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
 
         int theming = !gtkui_override_listview_colors ();
         if (theming) {
-            GdkColor *clr = &gtk_widget_get_style(theme_treeview)->fg[GTK_STATE_NORMAL];
-            float rgb[] = {clr->red/65535.f, clr->green/65535.f, clr->blue/65535.f};
+            GdkColor *clr = &gtk_widget_get_style(listview->theme_treeview)->fg[GTK_STATE_NORMAL];
+            float rgb[] = {clr->red/65535., clr->green/65535., clr->blue/65535.};
             draw_set_fg_color (&listview->grpctx, rgb);
         }
         else {
             GdkColor clr;
             gtkui_get_listview_group_text_color (&clr);
-            float rgb[] = {clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f};
+            float rgb[] = {clr.red/65535., clr.green/65535., clr.blue/65535.};
             draw_set_fg_color (&listview->grpctx, rgb);
         }
         int ew, eh;

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -26,11 +26,24 @@
 
 #include "ddblistview.h"
 
+typedef struct {
+    int id;
+    char *format;
+    char *bytecode;
+    int cover_size;
+    int new_cover_size;
+    int cover_load_timeout_id;
+    DdbListview *listview;
+} col_info_t;
+
 int
 rewrite_column_config (DdbListview *listview, const char *name);
 
+int
+is_album_art_column (void *user_data);
+
 void
-draw_album_art (DdbListview *listview, cairo_t *drawable, DdbListviewIter group_it, int column, int group_pinned, int grp_next_y, int x, int y, int width, int height);
+draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
 
 void
 draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int column, int iter, int x, int y, int width, int height);
@@ -45,7 +58,7 @@ void
 add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right);
 
 GtkWidget*
-create_headermenu (int groupby);
+create_headermenu (DdbListview *listview, int groupby);
 
 void
 set_last_playlist_cm (DdbListview *pl);
@@ -58,6 +71,9 @@ pl_common_init(void);
 
 void
 pl_common_free (void);
+
+void
+pl_common_free_col_info (void *data);
 
 int
 pl_common_get_group (DdbListview *listview, DdbListviewIter it, char *str, int size);

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -294,7 +294,7 @@ int search_get_idx (DdbListviewIter it) {
     DB_playItem_t *c = deadbeef->pl_get_first (PL_SEARCH);
     int idx = 0;
     while (c && c != it) {
-        DB_playItem_t *next = deadbeef->pl_get_next (c, PL_SEARCH); 
+        DB_playItem_t *next = deadbeef->pl_get_next (c, PL_SEARCH);
         deadbeef->pl_item_unref (c);
         c = next;
         idx++;
@@ -351,17 +351,6 @@ search_columns_changed (DdbListview *listview) {
 }
 
 static void
-search_col_free_user_data (void *data) {
-    if (data) {
-        col_info_t *inf = data;
-        if (inf->format) {
-            free (inf->format);
-        }
-        free (data);
-    }
-}
-
-static void
 search_handle_doubleclick (DdbListview *listview, DdbListviewIter iter, int idx) {
     deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, deadbeef->pl_get_idx_of ((DB_playItem_t *)iter), 0);
 }
@@ -381,7 +370,7 @@ search_delete_selected (void) {
 
 static void
 search_header_context_menu (DdbListview *ps, int column) {
-    GtkWidget *menu = create_headermenu (1);
+    GtkWidget *menu = create_headermenu (ps, 1);
     set_last_playlist_cm (ps); // playlist ptr for context menu
     set_active_column_cm (column);
     gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, ps, 3, gtk_get_current_event_time());
@@ -394,7 +383,7 @@ search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it,
 }
 
 static void
-search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height) 
+search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height)
 {
     pl_common_draw_group_title (listview, drawable, it, PL_SEARCH, x, y, width, height);
 }
@@ -429,9 +418,10 @@ static DdbListviewBinding search_binding = {
     .draw_group_title = search_draw_group_title,
 
     // columns
+    .is_album_art_column = is_album_art_column,
     .col_sort = search_col_sort,
     .columns_changed = search_columns_changed,
-    .col_free_user_data = search_col_free_user_data,
+    .col_free_user_data = pl_common_free_col_info,
 
     // callbacks
     .handle_doubleclick = search_handle_doubleclick,


### PR DESCRIPTION
Fix playlist artwork sizing (issue #1200).
Fix memory leak, GTK assertions, and possible crash when removing coverart widget during a load.
Support multiple album art columns with different widths.
Fix column type in edit dialog (tf changes).
Fix column minheight calculations to allow for padding (and potentially more complex calculations).
Fix a number of deprecation warnings (playqueue, GTK3 gtk_paint_*, gdk_window_get_pointer, gdk_cairo_set_source_color).
Add clip region to GTK3 draw event calls and make more use of the clip region.
Fix native themed column headers.
Fix pinned header exposes (issue #1301)