### PR TITLE
 gtkui: fix playlist header redraw after resize, fix horizontal scrolllbar misdraw, change scrolling steps

### DIFF
--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1321,7 +1321,19 @@ ddb_listview_get_hscroll_pos (DdbListview *listview) {
     return listview->hscrollpos;
 }
 
-#define MIN_COLUMN_WIDTH 16
+static int
+adjust_scrollbar (GtkWidget *scrollbar, int upper, int page_size) {
+    GtkRange *range = GTK_RANGE(scrollbar);
+    gdouble scrollpos = gtk_range_get_value(range);
+    GtkAdjustment *adj = gtk_range_get_adjustment(range);
+    if (scrollpos > 0 && scrollpos >= gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)) {
+        scrollpos = upper - page_size;
+    }
+    gtk_range_set_adjustment(range, GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, upper, SCROLL_STEP, page_size/2, page_size)));
+    gtk_range_set_value(range, round(scrollpos));
+    gtk_widget_show(scrollbar);
+    return round(gtk_range_get_value(range));
+}
 
 static void
 ddb_listview_list_setup_vscroll (DdbListview *ps) {
@@ -1334,12 +1346,7 @@ ddb_listview_list_setup_vscroll (DdbListview *ps) {
         gtk_widget_queue_draw (ps->list);
     }
     else {
-        GtkRange *range = GTK_RANGE(ps->scrollbar);
-        gdouble scrollpos = gtk_range_get_value(range);
-        gtk_range_set_adjustment(range, GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, ps->fullheight, SCROLL_STEP, a.height/2, a.height)));
-        gtk_range_set_value(range, scrollpos);
-        gtk_widget_show(ps->scrollbar);
-        ps->scrollpos = gtk_range_get_value(range);
+        ps->scrollpos = adjust_scrollbar(ps->scrollbar, ps->fullheight, a.height);
     }
 }
 
@@ -1360,12 +1367,7 @@ ddb_listview_list_setup_hscroll (DdbListview *ps) {
         gtk_widget_queue_draw (ps->header);
     }
     else {
-        GtkRange *range = GTK_RANGE(ps->hscrollbar);
-        gdouble scrollpos = gtk_range_get_value(range);
-        gtk_range_set_adjustment(range, GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, size, SCROLL_STEP, a.width/2, a.width)));
-        gtk_range_set_value(range, scrollpos);
-        gtk_widget_show (ps->hscrollbar);
-        ps->hscrollpos = gtk_range_get_value(range);
+        ps->hscrollpos = adjust_scrollbar(ps->hscrollbar, size, a.width);
     }
 }
 

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -376,7 +376,6 @@ ddb_listview_init(DdbListview *listview)
     listview->scrollpos = -1;
     gtk_table_resize (GTK_TABLE (listview), 2, 2);
     listview->scrollbar = gtk_vscrollbar_new (GTK_ADJUSTMENT (gtk_adjustment_new (0, 0, 1, 1, 0, 0)));
-    gtk_widget_show (listview->scrollbar);
     gtk_table_attach (GTK_TABLE (listview), listview->scrollbar, 1, 2, 0, 1,
             (GtkAttachOptions) (GTK_FILL),
             (GtkAttachOptions) (GTK_FILL), 0, 0);
@@ -421,7 +420,6 @@ ddb_listview_init(DdbListview *listview)
     gtk_widget_set_events (listview->list, events);
 
     listview->hscrollbar = gtk_hscrollbar_new (GTK_ADJUSTMENT (gtk_adjustment_new (0, 0, 0, 0, 0, 0)));
-    gtk_widget_show (listview->hscrollbar);
     gtk_table_attach (GTK_TABLE (listview), listview->hscrollbar, 0, 1, 1, 2,
             (GtkAttachOptions) (GTK_FILL),
             (GtkAttachOptions) (GTK_FILL), 0, 0);

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1326,7 +1326,9 @@ adjust_scrollbar (GtkWidget *scrollbar, int upper, int page_size) {
     GtkRange *range = GTK_RANGE(scrollbar);
     gdouble scrollpos = gtk_range_get_value(range);
     GtkAdjustment *adj = gtk_range_get_adjustment(range);
-    if (scrollpos > 0 && scrollpos >= gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)) {
+    int old_page_size = gtk_adjustment_get_page_size(adj);
+    int old_upper = gtk_adjustment_get_upper(adj);
+    if (scrollpos > 0 && page_size != old_page_size && scrollpos >= old_upper - old_page_size) {
         scrollpos = upper - page_size;
     }
     gtk_range_set_adjustment(range, GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, upper, SCROLL_STEP, page_size/2, page_size)));

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -2231,14 +2231,14 @@ ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state) {
             }
         }
         else {
-            gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_lower (adj));
+            gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_upper (adj));
         }
     }
     else if (keyval == GDK_Page_Up) {
         if (cursor > 0) {
             cursor -= 10;
             if (cursor < 0) {
-                gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_upper (adj));
+                gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_lower (adj));
                 cursor = 0;
             }
         }
@@ -2251,7 +2251,7 @@ ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state) {
     }
     else if (keyval == GDK_End) {
         cursor = ps->binding->count () - 1;
-        gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_lower (adj));
+        gtk_range_set_value (GTK_RANGE (range), gtk_adjustment_get_upper (adj));
     }
     else if (keyval == GDK_Home) {
         cursor = 0;


### PR DESCRIPTION
Fix header redraw when sizing after horizontal scrolling (issue #1308)
Work round horizontal scrollbar drawing artefact in GTK2 (issue #1308)
Fix scrolling to bottom of playlist momentarily while paging up (issue #1310)
Change scroll steps to be consistent horizontally and vertically, and when using a wheel over the drawing area or scrollbar (issue #1307)
Fingers crossed, caught up and merged all my changes.