### PR TITLE
Playlist column clipping, abstract treeview rendering and button styling

### DIFF
--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -145,6 +145,7 @@ struct _DdbListview {
 
     // scrolling
     int scroll_mode; // 0=select, 1=dragndrop
+    int scroll_pointer_x;
     int scroll_pointer_y;
     float scroll_direction;
     int scroll_active;

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -67,6 +67,11 @@ pl_common_init(void)
     gtk_widget_set_can_focus(theme_treeview, FALSE);
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(theme_treeview), TRUE);
     gtk_box_pack_start(GTK_BOX(gtk_bin_get_child(GTK_BIN(mainwin))), theme_treeview, FALSE, FALSE, 0);
+#if GTK_CHECK_VERSION(3,0,0)
+    GtkStyleContext *context = gtk_widget_get_style_context(theme_treeview);
+    gtk_style_context_add_class(context, GTK_STYLE_CLASS_CELL);
+    gtk_style_context_add_class(context, GTK_STYLE_CLASS_VIEW);
+#endif
     theme_button = mainwin;
 }
 

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -457,7 +457,11 @@ draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int id
             bold = gtkui_embolden_current_track;
             italic = gtkui_italic_current_track;
         }
+        cairo_save(cr);
+        cairo_rectangle(cr, x+5, y, cwidth-10, height);
+        cairo_clip(cr);
         draw_text_custom (&listview->listctx, x + 5, y + 3, cwidth-10, calign_right, DDB_LIST_FONT, bold, italic, text);
+        cairo_restore(cr);
     }
     if (playing_track) {
         deadbeef->pl_item_unref (playing_track);


### PR DESCRIPTION
Clip column text so that the ellipsis cannot overflow a column or header (issue #1306).
Abstract treeview background rendering to confine all the #ifdefs to one function (issue #1318 about transparent backgrounds is not fixed yet).
Make GTK3 styling for dragged headers more button-like.  They are styled like default buttons (not true column header buttons), pre-lit and focused, which is about the strongest button styling available in most themes.  In GTK2 the dragged headers still have the flat "selected" colouring.  Non-dragged buttons are still flat using the override colours.