### PR TITLE
gtkui: playqueue removal on context menu, fix for #1335

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -3508,7 +3508,7 @@ void
 plt_copy_items (playlist_t *to, int iter, playlist_t *from, playItem_t *before, uint32_t *indices, int cnt) {
     pl_lock ();
 
-    if (!from || !to | cnt == 0) {
+    if (!from || !to || cnt == 0) {
         pl_unlock ();
         return;
     }

--- a/playlist.c
+++ b/playlist.c
@@ -115,7 +115,7 @@ static uintptr_t mutex;
 // used at startup to prevent crashes
 static playlist_t dummy_playlist = {
     .refc = 1
-}; 
+};
 
 static int pl_order = -1; // mirrors "playback.order" config variable
 
@@ -398,7 +398,7 @@ plt_add (int before, const char *title) {
             p_after = playlists_head;
         }
     }
-    
+
     if (p_before) {
         p_before->next = plt;
     }
@@ -1393,7 +1393,7 @@ plt_insert_file_int (int visibility, playlist_t *playlist, playItem_t *after, co
                     return NULL;
                 }
             }
-            
+
             playItem_t *it = pl_item_alloc_init (fname, NULL);
             pl_replace_meta (it, ":FILETYPE", "content");
             after = plt_insert_item (addfiles_playlist ? addfiles_playlist : playlist, after, it);
@@ -1820,9 +1820,9 @@ plt_insert_item (playlist_t *playlist, playItem_t *after, playItem_t *it) {
     if (dur > 0) {
         playlist->totaltime += dur;
     }
-    
+
     plt_modified (playlist);
-    
+
     UNLOCK;
     return it;
 }
@@ -2392,7 +2392,7 @@ plt_load_int (int visibility, playlist_t *plt, playItem_t *after, const char *fn
                 ftype[ft] = 0;
                 pl_replace_meta (it, ":FILETYPE", ftype);
             }
-        
+
             float f;
 
             if (fread (&f, 1, 4, fp) != 4) {
@@ -2732,7 +2732,7 @@ pl_get_item_replaygain (playItem_t *it, int idx) {
     if (idx < 0 || idx > DDB_REPLAYGAIN_TRACKPEAK) {
         return 0;
     }
-    
+
     switch (idx) {
     case DDB_REPLAYGAIN_ALBUMGAIN:
     case DDB_REPLAYGAIN_TRACKGAIN:
@@ -3276,7 +3276,7 @@ pl_format_title_int (const char *escape_chars, playItem_t *it, int idx, char *s,
                     if (n < 1) {
                         fprintf (stderr, "pl_format_title_int: got unpredicted state while formatting escaped string. please report a bug.\n");
                         *ss = 0; // should never happen
-                        return -1; 
+                        return -1;
                     }
                     *s++ = '\'';
                     n--;
@@ -3508,35 +3508,34 @@ void
 plt_copy_items (playlist_t *to, int iter, playlist_t *from, playItem_t *before, uint32_t *indices, int cnt) {
     pl_lock ();
 
-    if (!from || !to) {
+    if (!from || !to | cnt == 0) {
         pl_unlock ();
         return;
     }
 
-    playItem_t *items[cnt];
+    playItem_t **items = malloc (cnt * sizeof(playItem_t *));
     for (int i = 0; i < cnt; i++) {
         playItem_t *it = from->head[iter];
-        int idx = 0;
-        while (it && idx < indices[i]) {
+        for (int idx = 0; it && idx < indices[i]; idx++) {
             it = it->next[iter];
-            idx++;
-        }
-        if (!it) {
-            trace ("pl_copy_items: warning: item %d not found in source plt_to\n", indices[i]);
         }
         items[i] = it;
-    }
-
-    for (int i = 0; i < cnt; i++) {
-        if (items[i]) {
-            playItem_t *it_new = pl_item_alloc ();
-            pl_item_copy (it_new, items[i]);
-
-            playItem_t *after = before ? before->prev[iter] : to->tail[iter];
-            pl_insert_item (after, it_new);
-            pl_item_unref (it_new);
+        if (!it) {
+            trace ("plt_copy_items: warning: item %d not found in source plt_to\n", indices[i]);
         }
     }
+    playItem_t *after = before ? before->prev[iter] : to->tail[iter];
+    for (int i = 0; i < cnt; i++) {
+        if (items[i]) {
+            playItem_t *new_it = pl_item_alloc();
+            pl_item_copy (new_it, items[i]);
+            pl_insert_item (after, new_it);
+            pl_item_unref (new_it);
+            after = new_it;
+        }
+    }
+    free(items);
+
     pl_unlock ();
 }
 

--- a/playlist.c
+++ b/playlist.c
@@ -3513,6 +3513,7 @@ plt_copy_items (playlist_t *to, int iter, playlist_t *from, playItem_t *before, 
         return;
     }
 
+    playItem_t *items[cnt];
     for (int i = 0; i < cnt; i++) {
         playItem_t *it = from->head[iter];
         int idx = 0;
@@ -3522,15 +3523,19 @@ plt_copy_items (playlist_t *to, int iter, playlist_t *from, playItem_t *before, 
         }
         if (!it) {
             trace ("pl_copy_items: warning: item %d not found in source plt_to\n", indices[i]);
-            continue;
         }
-        playItem_t *it_new = pl_item_alloc ();
-        pl_item_copy (it_new, it);
+        items[i] = it;
+    }
 
-        playItem_t *after = before ? before->prev[iter] : to->tail[iter];
-        pl_insert_item (after, it_new);
-        pl_item_unref (it_new);
+    for (int i = 0; i < cnt; i++) {
+        if (items[i]) {
+            playItem_t *it_new = pl_item_alloc ();
+            pl_item_copy (it_new, items[i]);
 
+            playItem_t *after = before ? before->prev[iter] : to->tail[iter];
+            pl_insert_item (after, it_new);
+            pl_item_unref (it_new);
+        }
     }
     pl_unlock ();
 }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -598,7 +598,7 @@ ddb_listview_list_realize                    (GtkWidget       *widget,
         gpointer         user_data)
 {
     GtkTargetEntry entry = {
-        .target = "DDB_URI_LIST",
+        .target = TARGET_PLAYITEMS,
         .flags = GTK_TARGET_SAME_APP,
         .info = TARGET_SAMEWIDGET
     };
@@ -1285,7 +1285,7 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
     }
     gchar *ptr=(char*)gtk_selection_data_get_data (data);
     gint len = gtk_selection_data_get_length (data);
-    if (target_type == 0) { // uris
+    if (target_type == TARGET_URILIST) { // uris
         // this happens when dropped from file manager
         char *mem = malloc (len+1);
         memcpy (mem, ptr, len);
@@ -1296,7 +1296,7 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
             UNREF (it);
         }
     }
-    else if (target_type == 1 && gtk_selection_data_get_format(data) == 32) { // list of 32bit ints, DDB_URI_LIST target
+    else if (target_type == TARGET_SAMEWIDGET && gtk_selection_data_get_format(data) == 32) { // list of 32bit ints, DDB_URI_LIST target
         uint32_t *d= (uint32_t *)ptr;
         int plt = *d;
         d++;
@@ -2116,7 +2116,7 @@ ddb_listview_list_mousemove (DdbListview *ps, GdkEventMotion *ev, int ex, int ey
             ps->dragwait = 0;
             ps->drag_source_playlist = deadbeef->plt_get_curr_idx ();
             GtkTargetEntry entry = {
-                .target = "DDB_URI_LIST",
+                .target = TARGET_PLAYITEMS,
                 .flags = GTK_TARGET_SAME_WIDGET,
                 .info = TARGET_SAMEWIDGET
             };

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1303,10 +1303,14 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
         int length = (len/4)-1;
         DdbListviewIter drop_before = it;
         // find last selected
-        while (drop_before && ps->binding->is_selected (drop_before)) {
-            DdbListviewIter next = PL_NEXT(drop_before);
-            UNREF (drop_before);
-            drop_before = next;
+        if (plt == deadbeef->plt_get_curr_idx ()) {
+            while (drop_before && ps->binding->is_selected (drop_before)) {
+                DdbListviewIter next = PL_NEXT(drop_before);
+                UNREF (drop_before);
+                drop_before = next;
+            }
+        }
+        while (plt == deadbeef->plt_get_curr_idx () && drop_before && ps->binding->is_selected (drop_before)) {
         }
         ddb_playlist_t *p = deadbeef->plt_get_for_idx (plt);
         if (p) {

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -31,6 +31,7 @@
 #include "../../deadbeef.h"
 
 // drag and drop targets
+#define TARGET_PLAYITEMS "DDB_PLAYITEM_LIST"
 enum {
     TARGET_URILIST,
     TARGET_SAMEWIDGET,

--- a/plugins/gtkui/ddbtabstrip.c
+++ b/plugins/gtkui/ddbtabstrip.c
@@ -117,9 +117,9 @@ ddb_tabstrip_realize (GtkWidget *widget) {
 
     ddb_tabstrip_send_configure (DDB_TABSTRIP (widget));
     GtkTargetEntry entry = {
-        .target = "STRING",
+        .target = TARGET_PLAYITEMS,
         .flags = GTK_TARGET_SAME_APP,
-        TARGET_SAMEWIDGET
+        .info = TARGET_SAMEWIDGET
     };
     gtk_drag_dest_set (widget, GTK_DEST_DEFAULT_MOTION | GTK_DEST_DEFAULT_DROP, &entry, 1, GDK_ACTION_COPY | GDK_ACTION_MOVE);
     gtk_drag_dest_add_uri_targets (widget);
@@ -267,7 +267,7 @@ on_tabstrip_drag_data_received         (GtkWidget       *widget,
 {
     gchar *ptr=(char*)gtk_selection_data_get_data (data);
     int len = gtk_selection_data_get_length (data);
-    if (target_type == 0) { // uris
+    if (target_type == TARGET_URILIST) { // uris
         // this happens when dropped from file manager
         char *mem = malloc (len+1);
         memcpy (mem, ptr, len);
@@ -275,7 +275,7 @@ on_tabstrip_drag_data_received         (GtkWidget       *widget,
         // we don't pass control structure, but there's only one drag-drop view currently
         gtkui_receive_fm_drop (NULL, mem, len);
     }
-    else if (target_type == 1) {
+    else if (target_type == TARGET_SAMEWIDGET) {
         uint32_t *d= (uint32_t *)ptr;
         int plt = *d;
         d++;


### PR DESCRIPTION
This fixes #1335 by activating the context menu item if any of the selected playlist items are in the playqueue.

The diff is showing previous commits in addition to this one.  Is this from the manual merge you did?