### PR TITLE
gtkui: Double click on plt tab starts playback

### DIFF
--- a/plugins/gtkui/ddbtabstrip.c
+++ b/plugins/gtkui/ddbtabstrip.c
@@ -964,6 +964,17 @@ on_tabstrip_button_press_event(GtkWidget      *widget,
         }
         if (tab_clicked != -1) {
             gtkui_playlist_set_curr (tab_clicked);
+
+            if (event->type == GDK_2BUTTON_PRESS) {
+                ddb_playlist_t *plt = deadbeef->plt_get_curr ();
+                int cur = deadbeef->plt_get_cursor (plt, PL_MAIN);
+                deadbeef->plt_unref (plt);
+
+                if (cur == -1) {
+                    cur = 0;
+                }
+                deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, cur, 0);
+            }
         }
         else {
             if (event->type == GDK_2BUTTON_PRESS) {


### PR DESCRIPTION
A double click on a playlist tab starts playback for that list. The
previous cursor position will determines the track to be played.

This patch implements #507 