### PR TITLE
gtkui: playlist message handling and sorting, search window, cursor following, playlist column editing

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -3536,7 +3536,6 @@ plt_search_reset (playlist_t *playlist) {
     LOCK;
     while (playlist->head[PL_SEARCH]) {
         playItem_t *next = playlist->head[PL_SEARCH]->next[PL_SEARCH];
-        playlist->head[PL_SEARCH]->selected = 0;
         playlist->head[PL_SEARCH]->next[PL_SEARCH] = NULL;
         playlist->head[PL_SEARCH]->prev[PL_SEARCH] = NULL;
         playlist->head[PL_SEARCH] = next;
@@ -3579,7 +3578,6 @@ plt_search_process (playlist_t *playlist, const char *text) {
     }
 
     for (playItem_t *it = playlist->head[PL_MAIN]; it; it = it->next[PL_MAIN]) {
-        it->selected = 0;
         if (*text) {
             DB_metaInfo_t *m = NULL;
             for (m = it->meta; m; m = m->next) {
@@ -3611,7 +3609,6 @@ plt_search_process (playlist_t *playlist, const char *text) {
                             else {
                                 playlist->head[PL_SEARCH] = playlist->tail[PL_SEARCH] = it;
                             }
-                            it->selected = 1;
                             playlist->count[PL_SEARCH]++;
                             break;
                         }
@@ -3628,7 +3625,6 @@ plt_search_process (playlist_t *playlist, const char *text) {
                         else {
                             playlist->head[PL_SEARCH] = playlist->tail[PL_SEARCH] = it;
                         }
-                        it->selected = 1;
                         playlist->count[PL_SEARCH]++;
                         *((char *)m->value-1) = cmpidx;
                         break;

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -290,10 +290,6 @@ action_deselect_all_handler_cb (void *user_data) {
     }
     deadbeef->pl_unlock ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
-    DdbListview *pl = DDB_LISTVIEW (lookup_widget (searchwin, "searchlist"));
-    if (pl) {
-        ddb_listview_refresh (pl, DDB_REFRESH_LIST);
-    }
     return FALSE;
 }
 
@@ -307,10 +303,6 @@ gboolean
 action_select_all_handler_cb (void *user_data) {
     deadbeef->pl_select_all ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
-    DdbListview *pl = DDB_LISTVIEW (lookup_widget (searchwin, "searchlist"));
-    if (pl) {
-        ddb_listview_refresh (pl, DDB_REFRESH_LIST);
-    }
     return FALSE;
 }
 
@@ -449,7 +441,7 @@ action_add_location_handler_cb (void *user_data) {
                         deadbeef->pl_item_unref (tail);
                     }
                     deadbeef->plt_add_files_end (plt, 0);
-                    playlist_refresh ();
+                    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
                 }
                 if (plt) {
                     deadbeef->plt_unref (plt);
@@ -472,7 +464,7 @@ static GtkWidget *helpwindow;
 gboolean
 action_show_help_handler_cb (void *user_data) {
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), _("help.txt"));
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), _("help.txt"));
     gtkui_show_info_window (fname, _("Help"), &helpwindow);
     return FALSE;
 }
@@ -640,7 +632,7 @@ action_show_track_properties_handler (DB_plugin_action_t *act, int ctx) {
 
 gboolean
 action_find_handler_cb (void *data) {
-    search_start ();       
+    search_start ();
     return FALSE;
 }
 
@@ -741,7 +733,7 @@ action_load_playlist_handler_cb (void *data) {
     gtk_file_filter_set_name (flt, _("Other files (*)"));
     gtk_file_filter_add_pattern (flt, "*");
     gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dlg), flt);
-    
+
     int res = gtk_dialog_run (GTK_DIALOG (dlg));
     // store folder
     gchar *folder = gtk_file_chooser_get_current_folder_uri (GTK_FILE_CHOOSER (dlg));
@@ -904,10 +896,10 @@ gboolean
 action_sort_custom_handler_cb (void *data) {
     GtkWidget *dlg = create_sortbydlg ();
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
-    
+
     GtkComboBox *combo = GTK_COMBO_BOX (lookup_widget (dlg, "sortorder"));
     GtkEntry *entry = GTK_ENTRY (lookup_widget (dlg, "sortfmt"));
-    
+
     gtk_combo_box_set_active (combo, deadbeef->conf_get_int ("gtkui.sortby_order", 0));
     deadbeef->conf_lock ();
     gtk_entry_set_text (entry, deadbeef->conf_get_str_fast ("gtkui.sortby_fmt_v2", ""));

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -352,7 +352,7 @@ on_about1_activate                     (GtkMenuItem     *menuitem,
     char s[200];
     snprintf (s, sizeof (s), _("About DeaDBeeF %s"), VERSION);
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), "about.txt");
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), "about.txt");
     gtkui_show_info_window (fname, s, &aboutwindow);
 }
 
@@ -365,7 +365,7 @@ on_changelog1_activate                 (GtkMenuItem     *menuitem,
     char s[200];
     snprintf (s, sizeof (s), _("DeaDBeeF %s ChangeLog"), VERSION);
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), "ChangeLog");
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), "ChangeLog");
     gtkui_show_info_window (fname, s, &changelogwindow);
 }
 
@@ -376,7 +376,7 @@ on_gpl1_activate                       (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), "COPYING.GPLv2");
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), "COPYING.GPLv2");
     gtkui_show_info_window (fname, "GNU GENERAL PUBLIC LICENSE Version 2", &gplwindow);
 }
 
@@ -387,7 +387,7 @@ on_lgpl1_activate                      (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), "COPYING.LGPLv2.1");
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), "COPYING.LGPLv2.1");
     gtkui_show_info_window (fname, "GNU LESSER GENERAL PUBLIC LICENSE Version 2.1", &lgplwindow);
 }
 
@@ -625,7 +625,7 @@ on_translators1_activate               (GtkMenuItem     *menuitem,
     char s[200];
     snprintf (s, sizeof (s), _("DeaDBeeF Translators"));
     char fname[PATH_MAX];
-    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_doc_dir (), "translators.txt");
+    snprintf (fname, sizeof (fname), "%s/%s", deadbeef->get_system_dir(DDB_SYS_DIR_DOC), "translators.txt");
     gtkui_show_info_window (fname, s, &translatorswindow);
 }
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -295,12 +295,6 @@ on_loop_disable_activate               (GtkMenuItem     *menuitem,
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 
-void
-on_searchlist_realize                  (GtkWidget       *widget,
-                                        gpointer         user_data)
-{
-}
-
 gboolean
 on_mainwin_delete_event                (GtkWidget       *widget,
                                         GdkEvent        *event,

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -163,31 +163,6 @@ on_searchentry_changed                 (GtkEditable     *editable,
                                         gpointer         user_data);
 
 gboolean
-on_searchheader_button_press_event     (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchheader_button_release_event   (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchheader_configure_event        (GtkWidget       *widget,
-                                        GdkEventConfigure *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchheader_expose_event           (GtkWidget       *widget,
-                                        GdkEventExpose  *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchheader_motion_notify_event    (GtkWidget       *widget,
-                                        GdkEventMotion  *event,
-                                        gpointer         user_data);
-
-gboolean
 on_searchlist_button_press_event       (GtkWidget       *widget,
                                         GdkEventButton  *event,
                                         gpointer         user_data);

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -163,34 +163,6 @@ on_searchentry_changed                 (GtkEditable     *editable,
                                         gpointer         user_data);
 
 gboolean
-on_searchlist_button_press_event       (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchlist_configure_event          (GtkWidget       *widget,
-                                        GdkEventConfigure *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchlist_expose_event             (GtkWidget       *widget,
-                                        GdkEventExpose  *event,
-                                        gpointer         user_data);
-
-gboolean
-on_searchlist_scroll_event             (GtkWidget       *widget,
-                                        GdkEvent        *event,
-                                        gpointer         user_data);
-
-void
-on_searchscroll_value_changed          (GtkRange        *range,
-                                        gpointer         user_data);
-
-void
-on_searchlist_realize                  (GtkWidget       *widget,
-                                        gpointer         user_data);
-
-gboolean
 on_header_button_press_event           (GtkWidget       *widget,
                                         GdkEventButton  *event,
                                         gpointer         user_data);
@@ -214,7 +186,6 @@ gboolean
 on_header_motion_notify_event          (GtkWidget       *widget,
                                         GdkEventMotion  *event,
                                         gpointer         user_data);
-
 
 void
 on_playlist_load_activate              (GtkMenuItem     *menuitem,
@@ -308,24 +279,12 @@ on_select_all1_activate                (GtkMenuItem     *menuitem,
                                         gpointer         user_data);
 
 void
-on_remove1_activate                    (GtkMenuItem     *menuitem,
-                                        gpointer         user_data);
-
-void
 on_find_activate                       (GtkMenuItem     *menuitem,
                                         gpointer         user_data);
 
 
 void
 on_help1_activate                      (GtkMenuItem     *menuitem,
-                                        gpointer         user_data);
-
-void
-on_playhscroll_value_changed           (GtkRange        *range,
-                                        gpointer         user_data);
-
-void
-on_searchhscroll_value_changed         (GtkRange        *range,
                                         gpointer         user_data);
 
 gboolean
@@ -411,10 +370,6 @@ on_title_activate                      (GtkMenuItem     *menuitem,
 
 void
 on_custom_activate                     (GtkMenuItem     *menuitem,
-                                        gpointer         user_data);
-
-void
-on_remove_column_activate              (GtkMenuItem     *menuitem,
                                         gpointer         user_data);
 
 void
@@ -522,10 +477,6 @@ on_remove_from_playback_queue1_activate
                                         gpointer         user_data);
 
 void
-on_remove2_activate                    (GtkMenuItem     *menuitem,
-                                        gpointer         user_data);
-
-void
 on_properties1_activate                (GtkMenuItem     *menuitem,
                                         gpointer         user_data);
 
@@ -559,14 +510,6 @@ on_searchwin_window_state_event        (GtkWidget       *widget,
 gboolean
 on_trackproperties_key_press_event     (GtkWidget       *widget,
                                         GdkEventKey     *event,
-                                        gpointer         user_data);
-
-void
-on_add_column_activate                 (GtkMenuItem     *menuitem,
-                                        gpointer         user_data);
-
-void
-on_edit_column_activate                (GtkMenuItem     *menuitem,
                                         gpointer         user_data);
 
 gboolean
@@ -1251,11 +1194,6 @@ on_hotkeys_actions_clicked             (GtkButton       *button,
 
 void
 on_hotkeys_defaults_clicked            (GtkButton       *button,
-                                        gpointer         user_data);
-
-gboolean
-on_searchwin_key_press_event           (GtkWidget       *widget,
-                                        GdkEventKey     *event,
                                         gpointer         user_data);
 
 void

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -916,14 +916,14 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
             fill_list_background(listview, cr, scrollx, 0, total_width, min(title_height, grp_next_y), clip);
 //            render_treeview_background(listview, cr, FALSE, TRUE, scrollx, 0, total_width, min(title_height, grp_next_y), clip);
             if (listview->binding->draw_group_title && title_height > 0) {
-                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, scrollx, min(0, grp_next_y-title_height), total_width, title_height);
+                listview->binding->draw_group_title(listview, cr, grp->head, scrollx, min(0, grp_next_y-title_height), total_width, title_height);
             }
         }
         else if (clip->y <= grp_y + title_height) {
             // draw normal group title
 //            render_treeview_background(listview, cr, FALSE, TRUE, scrollx, grp_y, total_width, title_height, clip);
             if (listview->binding->draw_group_title && title_height > 0) {
-                listview->binding->draw_group_title(listview, cr, grp->head, PL_MAIN, scrollx, grp_y, total_width, title_height);
+                listview->binding->draw_group_title(listview, cr, grp->head, scrollx, grp_y, total_width, title_height);
             }
         }
 
@@ -1494,7 +1494,7 @@ ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListvi
     int x = -ps->hscrollpos;
     for (DdbListviewColumn *c = ps->columns; c && x < x2; x += c->width, c = c->next, cidx++) {
         if (x + c->width > x1 && !ps->binding->is_album_art_column(c->user_data)) {
-            ps->binding->draw_column_data (ps, cr, it, idx, cidx, PL_MAIN, x, y, c->width, h);
+            ps->binding->draw_column_data (ps, cr, it, idx, cidx, x, y, c->width, h);
         }
     }
 }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1266,6 +1266,7 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
     gchar *ptr=(char*)gtk_selection_data_get_data (data);
     gint len = gtk_selection_data_get_length (data);
     if (target_type == TARGET_URILIST) { // uris
+        ddb_listview_clear_sort (ps);
         // this happens when dropped from file manager
         char *mem = malloc (len+1);
         memcpy (mem, ptr, len);
@@ -1277,6 +1278,7 @@ ddb_listview_list_drag_data_received         (GtkWidget       *widget,
         }
     }
     else if (target_type == TARGET_SAMEWIDGET && gtk_selection_data_get_format(data) == 32) { // list of 32bit ints, DDB_URI_LIST target
+        ddb_listview_clear_sort (ps);
         uint32_t *d= (uint32_t *)ptr;
         int plt = *d;
         d++;
@@ -1553,6 +1555,56 @@ ddb_listview_update_cursor (DdbListview *ps, int cursor)
         ddb_listview_draw_row (ps, prev, it);
         UNREF (it);
     }
+}
+
+void
+ddb_listview_set_cursor (DdbListview *listview, int cursor) {
+    ddb_listview_update_cursor (listview, cursor);
+    ddb_listview_select_single (listview, cursor);
+}
+
+struct set_cursor_t {
+    int cursor;
+    DdbListview *pl;
+};
+
+static gboolean
+set_cursor_and_scroll_cb (gpointer data) {
+    struct set_cursor_t *sc = (struct set_cursor_t *)data;
+    ddb_listview_set_cursor (sc->pl, sc->cursor);
+
+    int cursor_scroll = ddb_listview_get_row_pos (sc->pl, sc->cursor);
+    int newscroll = sc->pl->scrollpos;
+    GtkAllocation a;
+    gtk_widget_get_allocation (sc->pl->list, &a);
+    if (!gtkui_groups_pinned && cursor_scroll < sc->pl->scrollpos) {
+         newscroll = cursor_scroll;
+    }
+    else if (gtkui_groups_pinned && cursor_scroll < sc->pl->scrollpos + sc->pl->grouptitle_height) {
+        newscroll = cursor_scroll - sc->pl->grouptitle_height;
+    }
+    else if (cursor_scroll + sc->pl->rowheight >= sc->pl->scrollpos + a.height) {
+        newscroll = cursor_scroll + sc->pl->rowheight - a.height + 1;
+        if (newscroll < 0) {
+            newscroll = 0;
+        }
+    }
+    if (sc->pl->scrollpos != newscroll) {
+        GtkWidget *range = sc->pl->scrollbar;
+        gtk_range_set_value (GTK_RANGE (range), newscroll);
+    }
+
+    free (data);
+
+    return FALSE;
+}
+
+static void
+set_cursor_and_scroll (DdbListview *listview, int cursor) {
+    struct set_cursor_t *data = malloc (sizeof (struct set_cursor_t));
+    data->cursor = cursor;
+    data->pl = listview;
+    g_idle_add (set_cursor_and_scroll_cb, data);
 }
 
 static void
@@ -2157,7 +2209,7 @@ ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state) {
     }
     else {
         ps->shift_sel_anchor = cursor;
-        ddb_listview_set_cursor (ps, cursor);
+        set_cursor_and_scroll (ps, cursor);
     }
     return TRUE;
 }
@@ -2797,86 +2849,6 @@ ddb_listview_header_enter (GtkWidget *widget, GdkEventCrossing *event, gpointer 
     set_header_cursor(ps, x);
 }
 
-struct set_cursor_t {
-    int cursor;
-    int prev;
-    DdbListview *pl;
-    int noscroll;
-};
-
-static gboolean
-ddb_listview_set_cursor_cb (gpointer data) {
-    struct set_cursor_t *sc = (struct set_cursor_t *)data;
-
-    DdbListviewIter prev_it = sc->pl->binding->get_for_idx (sc->prev);
-    sc->pl->binding->set_cursor (sc->cursor);
-    int prev_selected = 0;
-
-    if (prev_it) {
-        prev_selected = sc->pl->binding->is_selected (prev_it);
-    }
-
-    ddb_listview_select_single (sc->pl, sc->cursor);
-
-    if (prev_it && !prev_selected) {
-        ddb_listview_draw_row (sc->pl, sc->prev, prev_it);
-    }
-
-    if (prev_it) {
-        sc->pl->binding->unref (prev_it);
-    }
-
-    if (!sc->noscroll) {
-        DdbListview *ps = sc->pl;
-
-        int cursor_scroll = ddb_listview_get_row_pos (sc->pl, sc->cursor);
-        int newscroll = sc->pl->scrollpos;
-        GtkAllocation a;
-        gtk_widget_get_allocation (sc->pl->list, &a);
-        if (!gtkui_groups_pinned && cursor_scroll < sc->pl->scrollpos) {
-             newscroll = cursor_scroll;
-        }
-        else if (gtkui_groups_pinned && cursor_scroll < sc->pl->scrollpos + ps->grouptitle_height) {
-            newscroll = cursor_scroll - ps->grouptitle_height;
-        }
-        else if (cursor_scroll + sc->pl->rowheight >= sc->pl->scrollpos + a.height) {
-            newscroll = cursor_scroll + sc->pl->rowheight - a.height + 1;
-            if (newscroll < 0) {
-                newscroll = 0;
-            }
-        }
-        if (sc->pl->scrollpos != newscroll) {
-            GtkWidget *range = sc->pl->scrollbar;
-            gtk_range_set_value (GTK_RANGE (range), newscroll);
-        }
-
-        free (data);
-    }
-    return FALSE;
-}
-
-void
-ddb_listview_set_cursor (DdbListview *pl, int cursor) {
-    int prev = pl->binding->cursor ();
-    struct set_cursor_t *data = malloc (sizeof (struct set_cursor_t));
-    data->prev = prev;
-    data->cursor = cursor;
-    data->pl = pl;
-    data->noscroll = 0;
-    g_idle_add (ddb_listview_set_cursor_cb, data);
-}
-
-void
-ddb_listview_set_cursor_noscroll (DdbListview *pl, int cursor) {
-    int prev = pl->binding->cursor ();
-    struct set_cursor_t *data = malloc (sizeof (struct set_cursor_t));
-    data->prev = prev;
-    data->cursor = cursor;
-    data->pl = pl;
-    data->noscroll = 1;
-    g_idle_add (ddb_listview_set_cursor_cb, data);
-}
-
 gboolean
 ddb_listview_list_button_press_event         (GtkWidget       *widget,
                                         GdkEventButton  *event,
@@ -2962,6 +2934,21 @@ ddb_listview_scroll_to (DdbListview *listview, int pos) {
     if (pos < listview->scrollpos || pos + listview->rowheight >= listview->scrollpos + a.height) {
         gtk_range_set_value (GTK_RANGE (listview->scrollbar), pos - a.height/2);
     }
+}
+
+void
+ddb_listview_track_focus (DdbListview *listview, DdbListviewIter it) {
+    ddb_playlist_t *plt = deadbeef->pl_get_playlist (it);
+    if (plt) {
+        deadbeef->plt_set_curr (plt);
+        int cursor = listview->binding->get_idx (it);
+        if (cursor != -1) {
+            ddb_listview_scroll_to (listview, cursor);
+            ddb_listview_set_cursor (listview, cursor);
+        }
+        deadbeef->plt_unref (plt);
+    }
+    deadbeef->pl_item_unref (it);
 }
 
 int

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -47,7 +47,7 @@
 #define DEFAULT_GROUP_TITLE_HEIGHT 30
 #define SCROLL_STEP 20
 #define AUTOSCROLL_UPDATE_FREQ 0.01f
-#define NUM_CHANGED_ROWS_BEFORE_FULL_REDRAW 10
+#define NUM_ROWS_TO_NOTIFY_SINGLY 10
 #define MIN_COLUMN_WIDTH 16
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
@@ -1445,18 +1445,21 @@ ddb_listview_header_expose (DdbListview *ps, cairo_t *cr, int x, int y, int w, i
 static void
 ddb_listview_deselect_all (DdbListview *listview)
 {
+    int notify_singly = listview->binding->sel_count() <= NUM_ROWS_TO_NOTIFY_SINGLY;
     DdbListviewIter it;
     int idx = 0;
     for (it = listview->binding->head (); it; idx++) {
         if (listview->binding->is_selected (it)) {
             listview->binding->select (it, 0);
             ddb_listview_draw_row (listview, idx, it);
-            listview->binding->selection_changed (listview, it, idx);
+            if (notify_singly) {
+                listview->binding->selection_changed (listview, it, idx);
+            }
         }
         it = next_playitem(listview, it);
     }
-    if (it) {
-        listview->binding->unref (it);
+    if (!notify_singly) {
+        listview->binding->selection_changed(listview, NULL, -1);
     }
 }
 
@@ -1470,6 +1473,7 @@ ddb_listview_select_group (DdbListview *listview, DdbListviewGroup *grp, int fir
     if (grp == NULL) {
         return;
     }
+    int notify_singly = grp->num_items <= NUM_ROWS_TO_NOTIFY_SINGLY;
     DdbListviewIter it = grp->head;
     listview->binding->ref (it);
     if (first_item_idx == -1) {
@@ -1483,14 +1487,18 @@ ddb_listview_select_group (DdbListview *listview, DdbListviewGroup *grp, int fir
             listview->binding->select (it, 1);
         }
         ddb_listview_draw_row (listview, first_item_idx + group_idx, it);
-        listview->binding->selection_changed (listview, it, first_item_idx + group_idx);
+        if (notify_singly) {
+            listview->binding->selection_changed (listview, it, first_item_idx + group_idx);
+        }
         it = next_playitem(listview, it);
     }
     if (it) {
         listview->binding->unref (it);
     }
 
-    ddb_listview_refresh (listview, DDB_REFRESH_LIST);
+    if (!notify_singly) {
+        listview->binding->selection_changed(listview, NULL, -1);
+    }
 }
 
 // Toggle selection of group
@@ -1528,34 +1536,16 @@ ddb_listview_toggle_group_selection (DdbListview *listview, DdbListviewGroup *gr
 
 static void
 ddb_listview_select_single (DdbListview *ps, int sel) {
-    int nchanged = 0;
     deadbeef->pl_lock ();
-
+    ddb_listview_deselect_all(ps);
     DdbListviewIter sel_it = ps->binding->get_for_idx (sel);
-    if (!sel_it) {
-        deadbeef->pl_unlock ();
-        return;
+    if (sel_it) {
+        ps->binding->select (sel_it, 1);
+        ddb_listview_draw_row (ps, sel, sel_it);
+        ps->binding->selection_changed (ps, sel_it, sel);
+        ps->binding->unref(sel_it);
     }
-
-    DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
-    while (it) {
-        int selected = deadbeef->pl_is_selected (it);
-        if (selected) {
-            deadbeef->pl_set_selected (it, 0);
-        }
-        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
-        UNREF (it);
-        it = next;
-    }
-    UNREF (it);
-
-    ps->binding->select (sel_it, 1);
-
-    UNREF (sel_it);
     deadbeef->pl_unlock ();
-
-    ddb_listview_refresh (ps, DDB_REFRESH_LIST);
-    ps->binding->selection_changed (ps, NULL, -1); // that means "selection changed a lot, redraw everything"
 }
 
 static void
@@ -1584,28 +1574,27 @@ ddb_listview_select_range (DdbListview *ps, int start, int end)
     for (it = ps->binding->head (); it; idx++) {
         if (idx >= start && idx <= end) {
             if (!ps->binding->is_selected (it)) {
-                ps->binding->select (it, 1);
                 nchanged++;
-                if (nchanged < NUM_CHANGED_ROWS_BEFORE_FULL_REDRAW) {
-                    ddb_listview_draw_row (ps, idx, it);
+                ps->binding->select (it, 1);
+                ddb_listview_draw_row (ps, idx, it);
+                if (nchanged <= NUM_ROWS_TO_NOTIFY_SINGLY) {
                     ps->binding->selection_changed (ps, it, idx);
                 }
             }
         }
         else {
             if (ps->binding->is_selected (it)) {
-                ps->binding->select (it, 0);
                 nchanged++;
-                if (nchanged < NUM_CHANGED_ROWS_BEFORE_FULL_REDRAW) {
-                    ddb_listview_draw_row (ps, idx, it);
+                ps->binding->select (it, 0);
+                ddb_listview_draw_row (ps, idx, it);
+                if (nchanged <= NUM_ROWS_TO_NOTIFY_SINGLY) {
                     ps->binding->selection_changed (ps, it, idx);
                 }
             }
         }
         it = next_playitem(ps, it);
     }
-    if (nchanged >= NUM_CHANGED_ROWS_BEFORE_FULL_REDRAW) {
-        ddb_listview_refresh (ps, DDB_REFRESH_LIST);
+    if (nchanged > NUM_ROWS_TO_NOTIFY_SINGLY) {
         ps->binding->selection_changed (ps, NULL, -1);
     }
 }
@@ -2988,7 +2977,7 @@ ddb_listview_scroll_to (DdbListview *listview, int pos) {
 
 int
 ddb_listview_is_scrolling (DdbListview *listview) {
-    return listview->dragwait;
+    return listview->dragwait || listview->areaselect || listview->drag_motion_y != -1;
 }
 
 /////// column management code

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1321,16 +1321,6 @@ ddb_listview_list_drag_leave                 (GtkWidget       *widget,
     ddb_listview_list_track_dragdrop (pl, -1, -1);
 }
 
-int
-ddb_listview_get_vscroll_pos (DdbListview *listview) {
-    return listview->scrollpos;
-}
-
-int
-ddb_listview_get_hscroll_pos (DdbListview *listview) {
-    return listview->hscrollpos;
-}
-
 static void
 adjust_scrollbar (GtkWidget *scrollbar, int upper, int page_size) {
     GtkRange *range = GTK_RANGE(scrollbar);
@@ -2727,7 +2717,7 @@ void
 ddb_listview_col_sort (DdbListview *listview) {
     for (DdbListviewColumn *c = listview->columns; c; c = c->next) {
         if (c->sort_order) {
-            listview->binding->col_sort(c->sort_order-1, c->user_data);
+            listview->binding->col_sort(c->sort_order, c->user_data);
         }
     }
 }
@@ -2768,21 +2758,16 @@ ddb_listview_header_button_release_event         (GtkWidget       *widget,
                                 cc->sort_order = 0;
                             }
                         }
-                        if (!c->sort_order || c->sort_order == 2) {
-                            c->sort_order = 1;
-                        }
-                        else {
-                            c->sort_order = 2;
-                        }
-                        ps->binding->col_sort(c->sort_order-1, c->user_data);
-                        gtk_widget_queue_draw(ps->list);
-                        gtk_widget_queue_draw(ps->header);
+                        c->sort_order = (c->sort_order + 1) % 3;
+                        ps->binding->col_sort (c->sort_order, c->user_data);
+                        gtk_widget_queue_draw (ps->list);
+                        gtk_widget_queue_draw (ps->header);
                     }
                 }
             }
             else {
                 ps->header_dragging = -1;
-                gtk_widget_queue_draw(ps->header);
+                gtk_widget_queue_draw (ps->header);
             }
         }
         set_header_cursor(ps, event->x);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -255,6 +255,7 @@ enum {
     DDB_REFRESH_VSCROLL = 4,
     DDB_REFRESH_LIST    = 8,
     DDB_LIST_CHANGED    = 16,
+    DDB_REFRESH_CONFIG  = 32,
 };
 
 
@@ -275,12 +276,6 @@ ddb_listview_get_row_pos (DdbListview *listview, int row_idx);
 
 void
 ddb_listview_groupcheck (DdbListview *listview);
-
-void
-ddb_listview_update_fonts (DdbListview *ps);
-
-void
-ddb_listview_header_update_fonts (DdbListview *ps);
 
 G_END_DECLS
 

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -99,7 +99,7 @@ typedef struct {
     // cols
     int (*is_album_art_column) (void *user_data);
     void (*columns_changed) (DdbListview *listview);
-    void (*col_sort) (int col, int sort_order, void *user_data);
+    void (*col_sort) (int sort_order, void *user_data);
     void (*col_free_user_data) (void *user_data);
 
     // callbacks
@@ -244,6 +244,8 @@ int
 ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *color_override, GdkColor *color, void **user_data);
 int
 ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
+void
+ddb_listview_col_sort (DdbListview *listview);
 
 void
 ddb_listview_show_header (DdbListview *listview, int show);
@@ -266,9 +268,6 @@ ddb_listview_invalidate_album_art_columns (DdbListview *listview);
 
 void
 ddb_listview_clear_sort (DdbListview *listview);
-
-void
-ddb_listview_lock_columns (DdbListview *lv, gboolean lock);
 
 int
 ddb_listview_get_row_pos (DdbListview *listview, int row_idx);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -177,7 +177,6 @@ struct _DdbListview {
     struct _DdbListviewGroup *groups;
     int groups_build_idx; // must be the same as playlist modification idx
     int fullheight;
-    int block_redraw_on_scroll;
     int grouptitle_height;
     int calculated_grouptitle_height;
 
@@ -229,8 +228,8 @@ void
 ddb_listview_set_cursor_noscroll (DdbListview *pl, int cursor);
 void
 ddb_listview_scroll_to (DdbListview *listview, int rowpos);
-void
-ddb_listview_set_vscroll (DdbListview *listview, int scroll);
+int
+ddb_listview_list_setup (DdbListview *listview, int scroll_to);
 int
 ddb_listview_is_scrolling (DdbListview *listview);
 int

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -257,49 +257,9 @@ enum {
     DDB_LIST_CHANGED    = 16,
 };
 
-void ddb_listview_refresh (DdbListview *listview, uint32_t flags);
-
-gboolean
-ddb_listview_list_drag_drop                  (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        gint             x,
-                                        gint             y,
-                                        guint            time,
-                                        gpointer         user_data);
 
 void
-ddb_listview_list_drag_data_get              (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        GtkSelectionData *data,
-                                        guint            info,
-                                        guint            time,
-                                        gpointer         user_data);
-
-void
-ddb_listview_list_drag_end                   (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        gpointer         user_data);
-
-void
-ddb_listview_list_drag_data_received         (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        gint             x,
-                                        gint             y,
-                                        GtkSelectionData *data,
-                                        guint            target_type,
-                                        guint            time,
-                                        gpointer         user_data);
-
-void
-ddb_listview_list_drag_leave                 (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        guint            time,
-                                        gpointer         user_data);
-
-void
-ddb_listview_list_drag_end                   (GtkWidget       *widget,
-                                        GdkDragContext  *drag_context,
-                                        gpointer         user_data);
+ddb_listview_refresh (DdbListview *listview, uint32_t flags);
 
 void
 ddb_listview_invalidate_album_art_columns (DdbListview *listview);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -92,9 +92,9 @@ typedef struct {
     void (*drag_n_drop) (DdbListviewIter before, DdbPlaylistHandle playlist_from, uint32_t *indices, int length, int copy);
     void (*external_drag_n_drop) (DdbListviewIter before, char *mem, int length);
 
-    void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int pl_iter, int x, int y, int width, int height);
+    void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int x, int y, int width, int height);
     void (*draw_album_art) (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
-    void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int idx, int column, int pl_iter, int x, int y, int width, int height);
+    void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int idx, int column, int x, int y, int width, int height);
 
     // cols
     int (*is_album_art_column) (void *user_data);
@@ -108,7 +108,7 @@ typedef struct {
     void (*handle_doubleclick) (DdbListview *listview, DdbListviewIter iter, int idx);
     void (*selection_changed) (DdbListview *listview, DdbListviewIter it, int idx);
     void (*delete_selected) (void);
-    void (*groups_changed) (DdbListview *listview, const char *format);
+    void (*groups_changed) (const char *format);
     void (*vscroll_changed) (int pos);
     void (*cursor_changed) (int pos);
     int (*modification_idx) (void);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -214,10 +214,6 @@ void
 ddb_listview_set_binding (DdbListview *listview, DdbListviewBinding *binding);
 void
 ddb_listview_draw_row (DdbListview *listview, int idx, DdbListviewIter iter);
-int
-ddb_listview_get_vscroll_pos (DdbListview *listview);
-int
-ddb_listview_get_hscroll_pos (DdbListview *listview);
 DdbListviewIter
 ddb_listview_get_iter_from_coord (DdbListview *listview, int x, int y);
 int

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -221,9 +221,9 @@ ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state);
 void
 ddb_listview_set_cursor (DdbListview *pl, int cursor);
 void
-ddb_listview_set_cursor_noscroll (DdbListview *pl, int cursor);
-void
 ddb_listview_scroll_to (DdbListview *listview, int rowpos);
+void
+ddb_listview_track_focus (DdbListview *listview, DdbListviewIter it);
 int
 ddb_listview_list_setup (DdbListview *listview, int scroll_to);
 int

--- a/plugins/gtkui/ddbtabstrip.c
+++ b/plugins/gtkui/ddbtabstrip.c
@@ -1027,7 +1027,6 @@ on_tabstrip_button_press_event(GtkWidget      *widget,
             if (tab_clicked != -1) {
                 deadbeef->plt_remove (tab_clicked);
                 // force invalidation of playlist cache
-                search_refresh ();
                 int playlist = deadbeef->plt_get_curr_idx ();
                 deadbeef->conf_set_int ("playlist.current", playlist);
             }

--- a/plugins/gtkui/drawing.h
+++ b/plugins/gtkui/drawing.h
@@ -95,6 +95,35 @@ draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h
 int
 draw_get_listview_rowheight (drawctx_t *ctx);
 
+int
+gtkui_listview_override_conf (const char *conf_str);
+
+int
+gtkui_listview_font_conf (const char *conf_str);
+
+int
+gtkui_listview_font_style_conf (const char *conf_str);
+
+int
+gtkui_listview_colors_conf (const char *conf_str);
+
+int
+gtkui_tabstrip_override_conf (const char *conf_str);
+
+int
+gtkui_tabstrip_colors_conf (const char *conf_str);
+
+int
+gtkui_tabstrip_font_conf (const char *conf_str);
+
+int
+gtkui_tabstrip_font_style_conf (const char *conf_str);
+
+int
+gtkui_bar_override_conf (const char *conf_str);
+
+int
+gtkui_bar_colors_conf (const char *conf_str);
 void
 gtkui_get_bar_foreground_color (GdkColor *clr);
 

--- a/plugins/gtkui/gdkdrawing.c
+++ b/plugins/gtkui/gdkdrawing.c
@@ -286,6 +286,56 @@ static int override_bar_colors = 0;
 static int override_tabstrip_colors = 0;
 
 int
+gtkui_listview_override_conf (const char *conf_str) {
+    return !strcmp(conf_str, "gtkui.override_listview_colors");
+}
+
+int
+gtkui_listview_font_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.font.listview", strlen("gtkui.font.listview"));
+}
+
+int
+gtkui_listview_font_style_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.italic", strlen("gtkui.italic")) || !strncmp(conf_str, "gtkui.embolden", strlen("gtkui.embolden"));
+}
+
+int
+gtkui_listview_colors_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.color.listview", strlen("gtkui.color.listview"));
+}
+
+int
+gtkui_tabstrip_override_conf (const char *conf_str) {
+    return !strcmp(conf_str, "gtkui.override_tabstrip_colors");
+}
+
+int
+gtkui_tabstrip_font_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.font.tabstrip", strlen("gtkui.font.tabstrip"));
+}
+
+int
+gtkui_tabstrip_font_style_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.tabstrip_italic", strlen("gtkui.tabstrip_italic")) || !strncmp(conf_str, "gtkui.tabstrip_embolden", strlen("gtkui.tabstrip_embolden"));
+}
+
+int
+gtkui_tabstrip_colors_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.color.tabstrip", strlen("gtkui.color.tabstrip"));
+}
+
+int
+gtkui_bar_override_conf (const char *conf_str) {
+    return !strcmp(conf_str, "gtkui.override_bar_colors");
+}
+
+int
+gtkui_bar_colors_conf (const char *conf_str) {
+    return !strncmp(conf_str, "gtkui.color.bar", strlen("gtkui.color.bar"));
+}
+
+int
 gtkui_override_listview_colors (void) {
     return override_listview_colors;
 }

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -73,7 +73,6 @@ DB_functions_t *deadbeef;
 
 // main widgets
 GtkWidget *mainwin;
-GtkWidget *searchwin;
 GtkStatusIcon *trayicon;
 GtkWidget *traymenu;
 
@@ -992,12 +991,7 @@ gtkui_thread (void *ctx) {
         gtk_widget_hide (menu);
     }
 
-    searchwin = create_searchwin ();
-    gtk_window_set_transient_for (GTK_WINDOW (searchwin), GTK_WINDOW (mainwin));
-
-    GtkWidget *search_playlist = lookup_widget (searchwin, "searchlist");
-    search_playlist_init (search_playlist);
-
+    search_playlist_init (mainwin);
     progress_init ();
     cover_art_init ();
 
@@ -1046,15 +1040,12 @@ gtkui_thread (void *ctx) {
     progress_destroy ();
     gtkui_hide_status_icon ();
     pl_common_free();
+    search_destroy ();
 //    draw_free ();
     titlebar_tf_free ();
     if (mainwin) {
         gtk_widget_destroy (mainwin);
         mainwin = NULL;
-    }
-    if (searchwin) {
-        gtk_widget_destroy (searchwin);
-        searchwin = NULL;
     }
     gdk_threads_leave ();
     return 0;

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -354,7 +354,7 @@ redraw_queued_tracks (DdbListview *pl) {
     int idx = 0;
     deadbeef->pl_lock ();
     for (it = deadbeef->pl_get_first (PL_MAIN); it; idx++) {
-        if (deadbeef->pl_playqueue_test (it) != -1) {
+        if (deadbeef->playqueue_test (it) != -1) {
             ddb_listview_draw_row (pl, idx, (DdbListviewIter)it);
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
@@ -545,7 +545,7 @@ gtkui_update_status_icon (gpointer unused) {
 
     if (!gtk_icon_theme_has_icon(theme, icon_name)) {
         char iconpath[1024];
-        snprintf (iconpath, sizeof (iconpath), "%s/deadbeef.png", deadbeef->get_prefix ());
+        snprintf (iconpath, sizeof (iconpath), "%s/deadbeef.png", deadbeef->get_system_dir(DDB_SYS_DIR_PREFIX));
         trayicon = gtk_status_icon_new_from_file(iconpath);
     }
     else {
@@ -971,7 +971,7 @@ gtkui_thread (void *ctx) {
     }
 
     gtk_disable_setlocale ();
-    add_pixmap_directory (deadbeef->get_pixmap_dir ());
+    add_pixmap_directory (deadbeef->get_system_dir(DDB_SYS_DIR_PIXMAP));
 
     // let's start some gtk
     g_thread_init (NULL);
@@ -1031,7 +1031,7 @@ gtkui_thread (void *ctx) {
     else {
         // try loading icon from $prefix/deadbeef.png (for static build)
         char iconpath[1024];
-        snprintf (iconpath, sizeof (iconpath), "%s/deadbeef.png", deadbeef->get_prefix ());
+        snprintf (iconpath, sizeof (iconpath), "%s/deadbeef.png", deadbeef->get_system_dir(DDB_SYS_DIR_PREFIX));
         gtk_window_set_icon_from_file (GTK_WINDOW (mainwin), iconpath, NULL);
     }
 
@@ -1062,8 +1062,8 @@ gtkui_thread (void *ctx) {
     searchwin = create_searchwin ();
     gtk_window_set_transient_for (GTK_WINDOW (searchwin), GTK_WINDOW (mainwin));
 
-    DdbListview *search_playlist = DDB_LISTVIEW (lookup_widget (searchwin, "searchlist"));
-    search_playlist_init (GTK_WIDGET (search_playlist));
+    GtkWidget *search_playlist = lookup_widget (searchwin, "searchlist");
+    search_playlist_init (search_playlist);
 
     progress_init ();
     cover_art_init ();
@@ -1623,7 +1623,7 @@ static ddb_gtkui_t plugin = {
     .gui.plugin.name = "GTK2 user interface",
     .gui.plugin.descr = "User interface using GTK+ 2.x",
 #endif
-    .gui.plugin.copyright = 
+    .gui.plugin.copyright =
         "GTK+ user interface for DeaDBeeF Player.\n"
         "Copyright (C) 2009-2015 Alexey Yakovenko and other contributors\n"
         "\n"

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -124,14 +124,6 @@ gtkpl_free (DdbListview *pl) {
 #endif
 }
 
-struct fromto_t {
-    DB_playItem_t *from;
-    DB_playItem_t *to;
-};
-
-static gboolean
-update_win_title_idle (gpointer data);
-
 // update status bar and window title
 static int sb_context_id = -1;
 static char sb_text[512];
@@ -346,20 +338,6 @@ activate_cb (gpointer nothing) {
     return FALSE;
 }
 
-void
-gtkpl_songchanged_wrapper (DB_playItem_t *from, DB_playItem_t *to) {
-    struct fromto_t *ft = malloc (sizeof (struct fromto_t));
-    ft->from = from;
-    ft->to = to;
-    if (from) {
-        deadbeef->pl_item_ref (from);
-    }
-    if (to) {
-        deadbeef->pl_item_ref (to);
-    }
-    g_idle_add (update_win_title_idle, ft);
-}
-
 const char *gtkui_default_titlebar_playing = "%artist% - %title% - DeaDBeeF-%_deadbeef_version%";
 const char *gtkui_default_titlebar_stopped = "DeaDBeeF-%_deadbeef_version%";
 
@@ -416,22 +394,16 @@ gtkui_set_titlebar (DB_playItem_t *it) {
     set_tray_tooltip (str);
 }
 
-void
-gtkui_trackinfochanged (DB_playItem_t *track) {
+static gboolean
+trackinfochanged_cb (gpointer data) {
+    DB_playItem_t *track = data;
     DB_playItem_t *curr = deadbeef->streamer_get_playing_track ();
     if (track == curr) {
         gtkui_set_titlebar (track);
     }
+    deadbeef->pl_item_unref (track);
     if (curr) {
         deadbeef->pl_item_unref (curr);
-    }
-}
-
-static gboolean
-trackinfochanged_cb (gpointer data) {
-    gtkui_trackinfochanged (data);
-    if (data) {
-        deadbeef->pl_item_unref ((DB_playItem_t *)data);
     }
     return FALSE;
 }
@@ -630,38 +602,6 @@ on_add_location_activate               (GtkMenuItem     *menuitem,
     gdk_threads_add_idle (action_add_location_handler_cb, NULL);
 }
 
-static gboolean
-update_win_title_idle (gpointer data) {
-    struct fromto_t *ft = (struct fromto_t *)data;
-    DB_playItem_t *from = ft->from;
-    DB_playItem_t *to = ft->to;
-    free (ft);
-
-    // update window title
-    if (from || to) {
-        if (to) {
-            DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
-            if (it) { // it might have been deleted after event was sent
-                gtkui_set_titlebar (it);
-                deadbeef->pl_item_unref (it);
-            }
-            else {
-                gtkui_set_titlebar (NULL);
-            }
-        }
-        else {
-            gtkui_set_titlebar (NULL);
-        }
-    }
-    if (from) {
-        deadbeef->pl_item_unref (from);
-    }
-    if (to) {
-        deadbeef->pl_item_unref (to);
-    }
-    return FALSE;
-}
-
 int
 gtkui_add_new_playlist (void) {
     int cnt = deadbeef->plt_get_count ();
@@ -740,11 +680,80 @@ gtkui_pl_add_files_end (void);
 DB_playItem_t *
 gtkui_plt_load (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname, int *pabort, int (*cb)(DB_playItem_t *it, void *data), void *user_data);
 
+static gboolean
+set_title_cb (gpointer data) {
+    gtkui_set_titlebar (NULL);
+    return FALSE;
+}
+
+static int
+cursor_is_set (ddb_playlist_t *plt, DB_playItem_t *it, int idx) {
+    return deadbeef->pl_is_selected (it) && idx == deadbeef->plt_get_cursor (plt, PL_MAIN) && deadbeef->plt_getselcount (plt) == 1;
+}
+
+static int
+scroll_is_set (ddb_playlist_t *plt, int idx) {
+    return idx == deadbeef->plt_get_scroll (plt);
+}
+
+static gboolean
+songchanged_cb (gpointer data) {
+    DB_playItem_t *it = data;
+    ddb_playlist_t *to_plt = deadbeef->pl_get_playlist (it);
+    if (to_plt) {
+        ddb_playlist_t *plt = deadbeef->plt_get_curr ();
+        if (plt) {
+            int idx = deadbeef->plt_get_item_idx (to_plt, it, PL_MAIN);
+            if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1) && (to_plt != plt || !cursor_is_set (plt, it, idx))) {
+                deadbeef->plt_deselect_all (to_plt);
+                deadbeef->pl_set_selected (it, 1);
+                if (plt == to_plt) {
+                    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+                }
+                deadbeef->plt_set_cursor (to_plt, PL_MAIN, idx);
+            }
+            if (deadbeef->conf_get_int ("playlist.scroll.followplayback", 1) && (to_plt != plt || !scroll_is_set (plt, idx))) {
+                deadbeef->plt_set_scroll (to_plt, -1);
+            }
+            deadbeef->plt_unref (plt);
+        }
+        deadbeef->plt_unref (to_plt);
+    }
+    deadbeef->pl_item_unref (it);
+
+    return FALSE;
+}
+
+static gboolean
+trackfocus_cb (gpointer data) {
+    deadbeef->pl_lock ();
+    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
+    if (it) {
+        ddb_playlist_t *plt = deadbeef->pl_get_playlist (it);
+        if (plt) {
+            deadbeef->plt_set_curr (plt);
+            int idx = deadbeef->plt_get_item_idx (plt, it, PL_MAIN);
+            if (idx != -1 && (!scroll_is_set (plt, idx) || !cursor_is_set (plt, it, idx))) {
+                deadbeef->plt_deselect_all (plt);
+                deadbeef->pl_set_selected (it, 1);
+                deadbeef->plt_set_scroll (plt, idx);
+                deadbeef->plt_set_cursor (plt, PL_MAIN, idx);
+                deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+            }
+            deadbeef->plt_unref (plt);
+        }
+        deadbeef->pl_item_unref (it);
+    }
+    deadbeef->pl_unlock ();
+    return FALSE;
+}
+
 int
 gtkui_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
     if (!gtkui_accept_messages) {
         return -1;
     }
+
     search_message(id, ctx, p1, p2);
     ddb_gtkui_widget_t *rootwidget = w_get_rootwidget ();
     if (rootwidget) {
@@ -756,9 +765,11 @@ gtkui_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
         g_idle_add (activate_cb, NULL);
         break;
     case DB_EV_SONGCHANGED:
-        {
-            ddb_event_trackchange_t *ev = (ddb_event_trackchange_t *)ctx;
-            gtkpl_songchanged_wrapper (ev->from, ev->to);
+        g_idle_add (set_title_cb, NULL);
+        ddb_event_trackchange_t *ev = (ddb_event_trackchange_t *)ctx;
+        if (ev->to) {
+            deadbeef->pl_item_ref (ev->to);
+            g_idle_add (songchanged_cb, ev->to);
         }
         break;
     case DB_EV_TRACKINFOCHANGED:
@@ -766,8 +777,8 @@ gtkui_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
             ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
             if (ev->track) {
                 deadbeef->pl_item_ref (ev->track);
+                g_idle_add (trackinfochanged_cb, ev->track);
             }
-            g_idle_add (trackinfochanged_cb, ev->track);
         }
         break;
     case DB_EV_PLAYLISTCHANGED:
@@ -777,6 +788,9 @@ gtkui_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
         break;
     case DB_EV_CONFIGCHANGED:
         g_idle_add (gtkui_on_configchanged, NULL);
+        break;
+    case DB_EV_TRACKFOCUSCURRENT:
+        g_idle_add (trackfocus_cb, NULL);
         break;
     case DB_EV_OUTPUTCHANGED:
         g_idle_add (outputchanged_cb, NULL);

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -129,9 +129,6 @@ int
 gtkui_get_curr_playlist_mod (void);
 
 void
-gtkui_trackinfochanged (DB_playItem_t *it);
-
-void
 mainwin_toggle_visible (void);
 
 void

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -94,15 +94,6 @@ enum {
 };
 
 void
-theme_set_cairo_source_rgb (cairo_t *cr, int col);
-
-void
-theme_set_fg_color (int col);
-
-void
-theme_set_bg_color (int col);
-
-void
 playlist_refresh (void);
 
 void

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -93,12 +93,6 @@ enum {
     COLO_COUNT
 };
 
-void
-playlist_refresh (void);
-
-void
-search_refresh (void);
-
 int
 gtkui_add_new_playlist (void);
 
@@ -137,9 +131,6 @@ gtkui_get_curr_playlist_mod (void);
 
 void
 gtkui_trackinfochanged (DB_playItem_t *it);
-
-gboolean
-redraw_queued_tracks_cb (gpointer plt);
 
 void
 mainwin_toggle_visible (void);

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -34,7 +34,6 @@
 
 extern DB_functions_t *deadbeef;
 extern GtkWidget *mainwin;
-extern GtkWidget *searchwin;
 
 extern int gtkui_embolden_selected_tracks;
 extern int gtkui_embolden_tracks;

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -263,10 +263,10 @@ main_playlist_init (GtkWidget *widget) {
     if (pl_common_load_column_config (listview, "gtkui.columns.playlist") < 0) {
         // create default set of columns
         pl_common_add_column_helper (listview, "♫", 50, DB_COLUMN_PLAYING, "%playstatus%", 0);
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, "%artist% - %album%", 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, "%track number%", 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, "%title%", 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, "%length%", 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, 0);
     }
     lock_column_config = 0;
 

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -248,9 +248,3 @@ main_playlist_init (GtkWidget *widget) {
         g_signal_connect (G_OBJECT (pl->list), "query-tooltip", G_CALLBACK (playlist_tooltip_handler), NULL);
     }
 }
-
-void
-main_refresh (void) {
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-}
-

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -62,7 +62,7 @@ main_get_cursor (void) {
 static void
 main_set_cursor (int cursor) {
     deadbeef->pl_set_cursor (PL_MAIN, cursor);
-    deadbeef->sendmessage (DB_EV_FOCUS_SELECTION, 0, PL_MAIN, cursor);
+    deadbeef->sendmessage (DB_EV_FOCUS_SELECTION, 0, cursor, PL_MAIN);
 }
 
 static DdbListviewIter main_head (void) {

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -136,6 +136,10 @@ static void main_selection_changed (DdbListview *ps, DdbListviewIter it, int idx
     pl_common_selection_changed (ps, PL_MAIN, it);
 }
 
+static void main_delete_selected (void) {
+    deadbeef->pl_delete_selected ();
+}
+
 static void
 main_groups_changed (const char* format) {
     deadbeef->conf_set_str ("gtkui.playlist.group_by", format);
@@ -206,7 +210,7 @@ static DdbListviewBinding main_binding = {
     .selection_changed = main_selection_changed,
     .header_context_menu = pl_common_header_context_menu,
     .list_context_menu = pl_common_list_context_menu,
-    .delete_selected = pl_common_delete_selected,
+    .delete_selected = main_delete_selected,
     .vscroll_changed = main_vscroll_changed,
     .modification_idx = gtkui_get_curr_playlist_mod,
 };

--- a/plugins/gtkui/mainplaylist.h
+++ b/plugins/gtkui/mainplaylist.h
@@ -33,12 +33,6 @@ void
 main_playlist_free (void);
 
 void
-main_refresh (void);
-
-int
-main_get_idx (DdbListviewIter it);
-
-void
 main_drag_n_drop (DdbListviewIter before, DdbPlaylistHandle from_playlist, uint32_t *indices, int length, int copy);
 
 #endif

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -617,8 +617,8 @@ static void
 on_remove2_activate                    (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
-    int cursor = deadbeef->pl_delete_selected ();
-    deadbeef->pl_save_current ();
+    get_context_menu_listview (menuitem)->binding->delete_selected ();
+    deadbeef->pl_save_current();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -1670,13 +1670,6 @@ pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
         draw_text_custom (&listview->grpctx, x + 5, y + height/2 - draw_get_listview_rowheight (&listview->grpctx)/2 + 3, ew+5, 0, DDB_GROUP_FONT, 0, 0, str);
         draw_line (&listview->grpctx, x + 5 + ew + 3, y+height/2, x + width, y+height/2);
     }
-}
-
-void
-pl_common_delete_selected (void) {
-    deadbeef->pl_delete_selected ();
-    deadbeef->pl_save_current();
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
 void

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -30,7 +30,6 @@
 #include "coverart.h"
 #include "drawing.h"
 #include "trkproperties.h"
-#include "mainplaylist.h"
 #include "support.h"
 #include "interface.h"
 #include "../libparser/parser.h"
@@ -486,7 +485,6 @@ add_to_playback_queue_activate     (GtkMenuItem     *menuitem,
         deadbeef->pl_item_unref (it);
         it = next;
     }
-    deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
 }
 
 static void
@@ -503,7 +501,6 @@ remove_from_playback_queue_activate
         deadbeef->pl_item_unref (it);
         it = next;
     }
-    deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
 }
 
 static void
@@ -542,7 +539,7 @@ reload_metadata_activate
         deadbeef->pl_item_unref (it);
         it = next;
     }
-    deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
 static void

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -120,7 +120,7 @@ pl_common_free_col_info (void *data) {
     if (info->bytecode) {
         free (info->bytecode);
     }
-    if (is_album_art_column(info)) {
+    if (pl_common_is_album_art_column(info)) {
         g_object_ref(info->listview->list);
         queue_cover_callback(coverart_release, info);
         if (info->cover_load_timeout_id) {
@@ -133,7 +133,7 @@ pl_common_free_col_info (void *data) {
 #define COL_CONF_BUFFER_SIZE 10000
 
 int
-rewrite_column_config (DdbListview *listview, const char *name) {
+pl_common_rewrite_column_config (DdbListview *listview, const char *name) {
     char *buffer = malloc (COL_CONF_BUFFER_SIZE);
     strcpy (buffer, "[");
     char *p = buffer+1;
@@ -198,7 +198,7 @@ min_group_height(void *user_data, int width) {
 
 ///// cover art display
 int
-is_album_art_column (void *user_data) {
+pl_common_is_album_art_column (void *user_data) {
     col_info_t *info = (col_info_t *)user_data;
     return info->id == DB_COLUMN_ALBUM_ART;
 }
@@ -301,7 +301,7 @@ cover_draw_exact (DB_playItem_t *it, int x, int min_y, int max_y, int width, int
 }
 
 void
-draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height) {
+pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height) {
     int art_width = width - ART_PADDING_HORZ * 2;
     int art_height = height - ART_PADDING_VERT * 2;
     if (art_width < 8 || art_height < 8 || !it) {
@@ -330,7 +330,7 @@ draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *use
 }
 
 void
-draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height) {
+pl_common_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height) {
     const char *ctitle;
     int cwidth;
     int calign_right;
@@ -474,7 +474,7 @@ draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int id
 }
 
 static void
-main_add_to_playback_queue_activate     (GtkMenuItem     *menuitem,
+add_to_playback_queue_activate     (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
     DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
@@ -489,8 +489,8 @@ main_add_to_playback_queue_activate     (GtkMenuItem     *menuitem,
     deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
 }
 
-void
-main_remove_from_playback_queue_activate
+static void
+remove_from_playback_queue_activate
                                         (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
@@ -506,8 +506,8 @@ main_remove_from_playback_queue_activate
     deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
 }
 
-void
-main_reload_metadata_activate
+static void
+reload_metadata_activate
                                         (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
@@ -545,8 +545,8 @@ main_reload_metadata_activate
     deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
 }
 
-void
-main_properties_activate                (GtkMenuItem     *menuitem,
+static void
+properties_activate                (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
     action_show_track_properties_handler_cb ((void *)(intptr_t)DDB_ACTION_CTX_SELECTION);
@@ -597,7 +597,7 @@ on_toggle_set_custom_title (GtkToggleButton *togglebutton, gpointer user_data) {
 }
 
 #ifndef DISABLE_CUSTOM_TITLE
-void
+static void
 on_set_custom_title_activate (GtkMenuItem *menuitem, gpointer user_data)
 {
     DdbListview *lv = user_data;
@@ -651,14 +651,14 @@ on_set_custom_title_activate (GtkMenuItem *menuitem, gpointer user_data)
 }
 #endif
 
-void
+static void
 on_remove_from_disk_activate                    (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
     action_delete_from_disk_handler_cb ((void *)(intptr_t)DDB_ACTION_CTX_SELECTION);
 }
 
-void
+static void
 actionitem_activate (GtkMenuItem     *menuitem,
                      DB_plugin_action_t *action)
 {
@@ -732,7 +732,7 @@ popup_menu_position_func (GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gp
 #endif
 
 void
-list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
+pl_common_list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
     clicked_idx = deadbeef->pl_get_idx_of (it);
     GtkWidget *playlist_menu;
     GtkWidget *add_to_playback_queue1;
@@ -951,13 +951,13 @@ list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
     g_object_set_data (G_OBJECT (properties1), "ps", listview);
 
     g_signal_connect ((gpointer) add_to_playback_queue1, "activate",
-            G_CALLBACK (main_add_to_playback_queue_activate),
+            G_CALLBACK (add_to_playback_queue_activate),
             NULL);
     g_signal_connect ((gpointer) remove_from_playback_queue1, "activate",
-            G_CALLBACK (main_remove_from_playback_queue_activate),
+            G_CALLBACK (remove_from_playback_queue_activate),
             NULL);
     g_signal_connect ((gpointer) reload_metadata, "activate",
-            G_CALLBACK (main_reload_metadata_activate),
+            G_CALLBACK (reload_metadata_activate),
             NULL);
     g_signal_connect ((gpointer) remove2, "activate",
             G_CALLBACK (on_remove2_activate),
@@ -973,7 +973,7 @@ list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
             listview);
 #endif
     g_signal_connect ((gpointer) properties1, "activate",
-            G_CALLBACK (main_properties_activate),
+            G_CALLBACK (properties_activate),
             NULL);
     gtk_menu_popup (GTK_MENU (playlist_menu), NULL, NULL, NULL/*popup_menu_position_func*/, listview, 0, gtk_get_current_event_time());
 }
@@ -981,21 +981,38 @@ list_context_menu (DdbListview *listview, DdbListviewIter it, int idx) {
 static DdbListview *last_playlist;
 static int active_column;
 
-void
+static void
+groups_changed (DdbListview *listview, const char *format)
+{
+    if (!format) {
+        return;
+    }
+    if (listview->group_format) {
+        free(listview->group_format);
+    }
+    if (listview->group_title_bytecode) {
+        free(listview->group_title_bytecode);
+        listview->group_title_bytecode = NULL;
+    }
+    listview->binding->groups_changed(format);
+    listview->group_format = strdup(format);
+    listview->group_title_bytecode = deadbeef->tf_compile(listview->group_format);
+    ddb_listview_refresh(listview, DDB_LIST_CHANGED | DDB_REFRESH_LIST);
+}
+
+static void
 on_group_by_none_activate              (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
-    last_playlist->binding->groups_changed (last_playlist, "");
-
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();
     if (plt) {
         deadbeef->plt_modified (plt);
         deadbeef->plt_unref (plt);
     }
-    main_refresh ();
+    groups_changed (last_playlist, "");
 }
 
-void
+static void
 on_pin_groups_active                   (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
@@ -1008,36 +1025,33 @@ on_pin_groups_active                   (GtkMenuItem     *menuitem,
         deadbeef->plt_modified (plt);
         deadbeef->plt_unref(plt);
     }
-    main_refresh ();
 }
 
-void
+static void
 on_group_by_artist_date_album_activate (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
-    last_playlist->binding->groups_changed (last_playlist, "%album artist% - [(%year%) ]%album%");
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();
     if (plt) {
         deadbeef->plt_modified (plt);
         deadbeef->plt_unref (plt);
     }
-    main_refresh ();
+    groups_changed (last_playlist, "%album artist% - [(%year%) ]%album%");
 }
 
-void
+static void
 on_group_by_artist_activate            (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
-    last_playlist->binding->groups_changed (last_playlist, "%artist%");
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();
     if (plt) {
         deadbeef->plt_modified (plt);
         deadbeef->plt_unref (plt);
     }
-    main_refresh ();
+    groups_changed (last_playlist, "%artist%");
 }
 
-void
+static void
 on_group_by_custom_activate            (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
@@ -1056,29 +1070,28 @@ on_group_by_custom_activate            (GtkMenuItem     *menuitem,
 
     if (response == GTK_RESPONSE_OK) {
         const gchar *text = gtk_entry_get_text (GTK_ENTRY (entry));
-        last_playlist->binding->groups_changed (last_playlist, text);
         ddb_playlist_t *plt = deadbeef->plt_get_curr ();
         if (plt) {
             deadbeef->plt_modified (plt);
             deadbeef->plt_unref (plt);
         }
-        main_refresh ();
+        groups_changed (last_playlist, text);
     }
     gtk_widget_destroy (dlg);
 }
 
-void
+static void
 set_last_playlist_cm (DdbListview *pl) {
     last_playlist = pl;
 }
 
-void
+static void
 set_active_column_cm (int col) {
     active_column = col;
 }
 
 int
-load_column_config (DdbListview *listview, const char *key) {
+pl_common_load_column_config (DdbListview *listview, const char *key) {
     deadbeef->conf_lock ();
     const char *json = deadbeef->conf_get_str_fast (key, NULL);
     json_error_t error;
@@ -1463,7 +1476,7 @@ on_remove_column_activate              (GtkMenuItem     *menuitem,
     ddb_listview_refresh (last_playlist, DDB_LIST_CHANGED | DDB_REFRESH_COLUMNS | DDB_REFRESH_LIST | DDB_REFRESH_HSCROLL);
 }
 
-GtkWidget*
+static GtkWidget*
 create_headermenu (DdbListview *listview, int groupby)
 {
   GtkWidget *headermenu;
@@ -1562,7 +1575,15 @@ create_headermenu (DdbListview *listview, int groupby)
 }
 
 void
-add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right) {
+pl_common_header_context_menu (DdbListview *ps, int column) {
+    GtkWidget *menu = create_headermenu (ps, 1);
+    set_last_playlist_cm (ps); // playlist ptr for context menu
+    set_active_column_cm (column);
+    gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, ps, 3, gtk_get_current_event_time());
+}
+
+void
+pl_common_add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right) {
     if (!format) {
         format = "";
     }
@@ -1649,3 +1670,9 @@ pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
     }
 }
 
+void
+pl_common_delete_selected (void) {
+    deadbeef->pl_delete_selected ();
+    deadbeef->pl_save_current();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+}

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1015,7 +1015,7 @@ on_pin_groups_active                   (GtkMenuItem     *menuitem,
 {
     int old_val = deadbeef->conf_get_int ("playlist.pin.groups", 0);
     deadbeef->conf_set_int ("playlist.pin.groups", old_val ? 0 : 1);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, (uintptr_t)"playlist.pin.groups", 0, 0);
     gtk_check_menu_item_toggled(GTK_CHECK_MENU_ITEM(menuitem));
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();
     if (plt) {

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1673,3 +1673,16 @@ pl_common_delete_selected (void) {
     deadbeef->pl_save_current();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
+
+void
+pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it) {
+    if (it) {
+        ddb_event_track_t *ev = (ddb_event_track_t *)deadbeef->event_alloc(DB_EV_TRACKINFOCHANGED);
+        ev->track = it;
+        ps->binding->ref(ev->track);
+        deadbeef->event_send((ddb_event_t *)ev, DDB_PLAYLIST_CHANGE_SELECTION, iter);
+    }
+    else {
+        deadbeef->sendmessage(DB_EV_PLAYLISTCHANGED, (uintptr_t)ps, DDB_PLAYLIST_CHANGE_SELECTION, iter);
+    }
+}

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1314,25 +1314,25 @@ init_column (col_info_t *inf, int id, const char *format) {
         inf->id = DB_COLUMN_ALBUM_ART;
         break;
     case 3:
-        inf->format = strdup ("$if(%artist%,%artist%,Unknown Artist)[ - %album%]");
+        inf->format = strdup (COLUMN_FORMAT_ARTISTALBUM);
         break;
     case 4:
-        inf->format = strdup ("$if(%artist%,%artist%,Unknown Artist)");
+        inf->format = strdup (COLUMN_FORMAT_ARTIST);
         break;
     case 5:
-        inf->format = strdup ("%album%");
+        inf->format = strdup (COLUMN_FORMAT_ALBUM);
         break;
     case 6:
-        inf->format = strdup ("%title%");
+        inf->format = strdup (COLUMN_FORMAT_TITLE);
         break;
     case 7:
-        inf->format = strdup ("%length%");
+        inf->format = strdup (COLUMN_FORMAT_LENGTH);
         break;
     case 8:
-        inf->format = strdup ("%track number%");
+        inf->format = strdup (COLUMN_FORMAT_TRACKNUMBER);
         break;
     case 9:
-        inf->format = strdup ("$if(%album artist%,%album artist%,Unknown Artist)");
+        inf->format = strdup (COLUMN_FORMAT_BAND);
         break;
     default:
         inf->format = strdup (format);
@@ -1406,25 +1406,25 @@ on_edit_column_activate                (GtkMenuItem     *menuitem,
     int idx = 10;
     if (inf->id == -1) {
         if (inf->format) {
-            if (!strcmp (inf->format, "%artist% - %album%")) {
+            if (!strcmp (inf->format, COLUMN_FORMAT_ARTISTALBUM)) {
                 idx = 3;
             }
-            else if (!strcmp (inf->format, "%artist%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_ARTIST)) {
                 idx = 4;
             }
-            else if (!strcmp (inf->format, "%album%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_ALBUM)) {
                 idx = 5;
             }
-            else if (!strcmp (inf->format, "%title%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_TITLE)) {
                 idx = 6;
             }
-            else if (!strcmp (inf->format, "%length%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_LENGTH)) {
                 idx = 7;
             }
-            else if (!strcmp (inf->format, "%track number%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_TRACKNUMBER)) {
                 idx = 8;
             }
-            else if (!strcmp (inf->format, "%album artist%")) {
+            else if (!strcmp (inf->format, COLUMN_FORMAT_BAND)) {
                 idx = 9;
             }
         }

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -74,9 +74,6 @@ void
 pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height);
 
 void
-pl_common_delete_selected (void);
-
-void
 pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it);
 
 void

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -26,6 +26,14 @@
 
 #include "ddblistview.h"
 
+#define COLUMN_FORMAT_ARTISTALBUM "$if(%artist%,%artist%,Unknown Artist)[ - %album%]"
+#define COLUMN_FORMAT_ARTIST "$if(%artist%,%artist%,Unknown Artist)"
+#define COLUMN_FORMAT_ALBUM "%album%"
+#define COLUMN_FORMAT_TITLE "%title%"
+#define COLUMN_FORMAT_LENGTH "%length%"
+#define COLUMN_FORMAT_TRACKNUMBER "%track number%"
+#define COLUMN_FORMAT_BAND "$if(%album artist%,%album artist%,Unknown Artist)"
+
 typedef struct {
     int id;
     char *format;

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -37,34 +37,28 @@ typedef struct {
 } col_info_t;
 
 int
-rewrite_column_config (DdbListview *listview, const char *name);
+pl_common_rewrite_column_config (DdbListview *listview, const char *name);
 
 int
-is_album_art_column (void *user_data);
+pl_common_is_album_art_column (void *user_data);
 
 void
-draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
+pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
 
 void
-draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height);
+pl_common_draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height);
 
 void
-list_context_menu (DdbListview *listview, DdbListviewIter it, int idx);
+pl_common_list_context_menu (DdbListview *listview, DdbListviewIter it, int idx);
 
 int
-load_column_config (DdbListview *listview, const char *key);
+pl_common_load_column_config (DdbListview *listview, const char *key);
 
 void
-add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right);
-
-GtkWidget*
-create_headermenu (DdbListview *listview, int groupby);
+pl_common_add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right);
 
 void
-set_last_playlist_cm (DdbListview *pl);
-
-void
-set_active_column_cm (int col);
+pl_common_header_context_menu (DdbListview *ps, int column);
 
 void
 pl_common_init(void);
@@ -80,5 +74,8 @@ pl_common_get_group (DdbListview *listview, DdbListviewIter it, char *str, int s
 
 void
 pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height);
+
+void
+pl_common_delete_selected (void);
 
 #endif // __PLCOLUMNS_H

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -34,16 +34,6 @@
 #define COLUMN_FORMAT_TRACKNUMBER "%track number%"
 #define COLUMN_FORMAT_BAND "$if(%album artist%,%album artist%,Unknown Artist)"
 
-typedef struct {
-    int id;
-    char *format;
-    char *bytecode;
-    int cover_size;
-    int new_cover_size;
-    int cover_load_timeout_id;
-    DdbListview *listview;
-} col_info_t;
-
 int
 pl_common_rewrite_column_config (DdbListview *listview, const char *name);
 
@@ -88,5 +78,11 @@ pl_common_delete_selected (void);
 
 void
 pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it);
+
+void
+pl_common_col_sort (int sort_order, int iter, void *user_data);
+
+void
+pl_common_set_group_format (DdbListview *listview, char *format_conf);
 
 #endif // __PLCOLUMNS_H

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -86,4 +86,7 @@ pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
 void
 pl_common_delete_selected (void);
 
+void
+pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it);
+
 #endif // __PLCOLUMNS_H

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -85,7 +85,6 @@ on_remove_playlist1_activate           (GtkMenuItem     *menuitem,
 {
     if (pltmenu_idx != -1) {
         deadbeef->plt_remove (pltmenu_idx);
-        search_refresh ();
         int playlist = deadbeef->plt_get_curr_idx ();
         deadbeef->conf_set_int ("playlist.current", playlist);
     }

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -622,7 +622,35 @@ on_configure_plugin_clicked            (GtkButton       *button,
 }
 
 static void
-color_set_helper (GtkColorButton  *colorbutton, gpointer user_data, const char* conf_str)
+override_set_helper (GtkToggleButton  *togglebutton, const char* conf_str, const char *group_name)
+{
+    int active = gtk_toggle_button_get_active (togglebutton);
+    deadbeef->conf_set_int (conf_str, active);
+    gtk_widget_set_sensitive (lookup_widget (prefwin, group_name), active);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, (uintptr_t)conf_str, 0, 0);
+    gtkui_init_theme_colors ();
+    prefwin_init_theme_colors ();
+}
+
+static void
+font_set_helper (GtkFontButton *fontbutton, const char* conf_str)
+{
+    deadbeef->conf_set_str (conf_str, gtk_font_button_get_font_name (fontbutton));
+    gtkui_init_theme_colors ();
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, (uintptr_t)conf_str, 0, 0);
+}
+
+static int
+font_style_set_helper (GtkToggleButton  *togglebutton, const char* conf_str)
+{
+    int active = gtk_toggle_button_get_active (togglebutton);
+    deadbeef->conf_set_int (conf_str, active);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, (uintptr_t)conf_str, 0, 0);
+    return active;
+}
+
+static void
+color_set_helper (GtkColorButton *colorbutton, const char* conf_str)
 {
     if (conf_str == NULL) {
         return;
@@ -632,15 +660,14 @@ color_set_helper (GtkColorButton  *colorbutton, gpointer user_data, const char* 
     char str[100];
     snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
     deadbeef->conf_set_str (conf_str, str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, (uintptr_t)conf_str, 0, 0);
     gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
 }
 void
 on_tabstrip_light_color_set            (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_light");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_light");
 }
 
 
@@ -648,7 +675,7 @@ void
 on_tabstrip_mid_color_set              (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_mid");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_mid");
 }
 
 
@@ -656,93 +683,78 @@ void
 on_tabstrip_dark_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_dark");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_dark");
 }
 
 void
 on_tabstrip_base_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_base");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_base");
 }
 
 void
 on_tabstrip_text_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_text");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_text");
 }
 
 void
 on_tabstrip_selected_text_color_set    (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_selected_text");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_selected_text");
 }
 
 void
 on_tabstrip_playing_bold_toggled       (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.tabstrip_embolden_playing", active);
-    gtkui_tabstrip_embolden_playing = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_tabstrip_embolden_playing = font_style_set_helper (togglebutton, "gtkui.tabstrip_embolden_playing");
 }
 
 void
 on_tabstrip_playing_italic_toggled     (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.tabstrip_italic_playing", active);
-    gtkui_tabstrip_italic_playing = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_tabstrip_italic_playing = font_style_set_helper (togglebutton, "gtkui.tabstrip_italic_playing");
 }
 
 void
 on_tabstrip_selected_bold_toggled      (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.tabstrip_embolden_selected", active);
-    gtkui_tabstrip_embolden_selected = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_tabstrip_embolden_selected = font_style_set_helper (togglebutton, "gtkui.tabstrip_embolden_selected");
 }
 
 void
 on_tabstrip_selected_italic_toggled    (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.tabstrip_italic_selected", active);
-    gtkui_tabstrip_italic_selected = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_tabstrip_italic_selected = font_style_set_helper (togglebutton, "gtkui.tabstrip_italic_selected");
 }
 
 void
 on_tabstrip_text_font_set              (GtkFontButton   *fontbutton,
                                         gpointer         user_data)
 {
-    deadbeef->conf_set_str ("gtkui.font.tabstrip_text", gtk_font_button_get_font_name (fontbutton));
-    gtkui_init_theme_colors ();
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    gtk_widget_queue_draw (mainwin);
+    font_set_helper (fontbutton, "gtkui.font.tabstrip_text");
 }
 
 void
 on_tabstrip_playing_text_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_playing_text");
+    color_set_helper (colorbutton, "gtkui.color.tabstrip_playing_text");
 }
 
 void
 on_bar_foreground_color_set            (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.bar_foreground");
+    color_set_helper (colorbutton, "gtkui.color.bar_foreground");
+    eq_redraw ();
 }
 
 
@@ -750,21 +762,15 @@ void
 on_bar_background_color_set            (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.bar_background");
+    color_set_helper (colorbutton, "gtkui.color.bar_background");
+    eq_redraw ();
 }
 
 void
 on_override_listview_colors_toggled    (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (togglebutton);
-    deadbeef->conf_set_int ("gtkui.override_listview_colors", active);
-    gtk_widget_set_sensitive (lookup_widget (prefwin, "listview_colors_group"), active);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    prefwin_init_theme_colors ();
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    gtk_widget_queue_draw (mainwin);
+    override_set_helper (togglebutton, "gtkui.override_listview_colors", "listview_colors_group");
 }
 
 
@@ -772,32 +778,28 @@ void
 on_listview_even_row_color_set         (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_even_row");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_even_row");
 }
 
 void
 on_listview_odd_row_color_set          (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_odd_row");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_odd_row");
 }
 
 void
 on_listview_selected_row_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_selection");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_selection");
 }
 
 void
 on_listview_text_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_text");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_text");
 }
 
 
@@ -805,125 +807,91 @@ void
 on_listview_selected_text_color_set    (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_selected_text");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_selected_text");
 }
 
 void
 on_listview_cursor_color_set           (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_cursor");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_cursor");
 }
 
 void
 on_listview_playing_text_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_playing_text");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_playing_text");
 }
 
 void
 on_listview_group_text_color_set       (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_group_text");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, "gtkui.color.listview_group_text");
 }
 
 void
 on_listview_group_text_font_set        (GtkFontButton   *fontbutton,
                                         gpointer         user_data)
 {
-    deadbeef->conf_set_str ("gtkui.font.listview_group_text", gtk_font_button_get_font_name (fontbutton));
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    gtk_widget_queue_draw (mainwin);
+    font_set_helper (fontbutton, "gtkui.font.listview_group_text");
 }
 
 void
 on_listview_text_font_set              (GtkFontButton   *fontbutton,
                                         gpointer         user_data)
 {
-    deadbeef->conf_set_str ("gtkui.font.listview_text", gtk_font_button_get_font_name (fontbutton));
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    gtk_widget_queue_draw (mainwin);
+    font_set_helper (fontbutton, "gtkui.font.listview_text");
 }
 
 void
 on_listview_playing_text_bold_toggled  (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.embolden_current_track", active);
-    gtkui_embolden_current_track = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_embolden_current_track = font_style_set_helper (togglebutton, "gtkui.embolden_current_track");
 }
 
 void
 on_listview_playing_text_italic_toggled (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.italic_current_track", active);
-    gtkui_italic_current_track = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_italic_current_track = font_style_set_helper (togglebutton, "gtkui.italic_current_track");
 }
 
 void
 on_listview_selected_text_bold_toggled (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.embolden_selected_tracks", active);
-    gtkui_embolden_selected_tracks = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_embolden_selected_tracks = font_style_set_helper (togglebutton, "gtkui.embolden_selected_tracks");
 }
 
 void
 on_listview_selected_text_italic_toggled (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.italic_selected_tracks", active);
-    gtkui_italic_selected_tracks = active;
-    gtk_widget_queue_draw (mainwin);
+    gtkui_italic_selected_tracks = font_style_set_helper (togglebutton, "gtkui.italic_selected_tracks");
 }
 
 void
 on_listview_column_text_color_set      (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    color_set_helper (colorbutton, user_data, "gtkui.color.listview_column_text");
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    color_set_helper (colorbutton, "gtkui.color.listview_column_text");
 }
 
 void
 on_listview_column_text_font_set       (GtkFontButton   *fontbutton,
                                         gpointer         user_data)
 {
-    deadbeef->conf_set_str ("gtkui.font.listview_column_text", gtk_font_button_get_font_name (fontbutton));
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    font_set_helper (fontbutton, "gtkui.font.listview_column_text");
 }
 
 void
 on_override_bar_colors_toggled         (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (togglebutton);
-    deadbeef->conf_set_int ("gtkui.override_bar_colors", active);
-    gtk_widget_set_sensitive (lookup_widget (prefwin, "bar_colors_group"), active);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    prefwin_init_theme_colors ();
+    override_set_helper (togglebutton, "gtkui.override_bar_colors", "bar_colors_group");
     eq_redraw ();
 }
 
@@ -931,13 +899,7 @@ void
 on_override_tabstrip_colors_toggled    (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
-    int active = gtk_toggle_button_get_active (togglebutton);
-    deadbeef->conf_set_int ("gtkui.override_tabstrip_colors", active);
-    gtk_widget_set_sensitive (lookup_widget (prefwin, "tabstrip_colors_group"), active);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    prefwin_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    override_set_helper (togglebutton, "gtkui.override_tabstrip_colors", "tabstrip_colors_group");
 }
 
 void

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -42,13 +42,6 @@
 #include "wingeom.h"
 #include "hotkeys.h"
 
-#define GLADE_HOOKUP_OBJECT(component,widget,name) \
-  g_object_set_data_full (G_OBJECT (component), name, \
-    g_object_ref (G_OBJECT (widget)), (GDestroyNotify) g_object_unref)
-
-#define GLADE_HOOKUP_OBJECT_NO_REF(component,widget,name) \
-  g_object_set_data (G_OBJECT (component), name, widget)
-
 static GtkWidget *prefwin;
 
 static char alsa_device_names[100][64];
@@ -694,7 +687,6 @@ on_tabstrip_playing_bold_toggled       (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.tabstrip_embolden_playing", active);
     gtkui_tabstrip_embolden_playing = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -705,7 +697,6 @@ on_tabstrip_playing_italic_toggled     (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.tabstrip_italic_playing", active);
     gtkui_tabstrip_italic_playing = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -716,7 +707,6 @@ on_tabstrip_selected_bold_toggled      (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.tabstrip_embolden_selected", active);
     gtkui_tabstrip_embolden_selected = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -727,7 +717,6 @@ on_tabstrip_selected_italic_toggled    (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.tabstrip_italic_selected", active);
     gtkui_tabstrip_italic_selected = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -737,7 +726,6 @@ on_tabstrip_text_font_set              (GtkFontButton   *fontbutton,
 {
     deadbeef->conf_set_str ("gtkui.font.tabstrip_text", gtk_font_button_get_font_name (fontbutton));
     gtkui_init_theme_colors ();
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     gtk_widget_queue_draw (mainwin);
@@ -775,7 +763,6 @@ on_override_listview_colors_toggled    (GtkToggleButton *togglebutton,
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
     prefwin_init_theme_colors ();
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     gtk_widget_queue_draw (mainwin);
 }
@@ -786,7 +773,6 @@ on_listview_even_row_color_set         (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_even_row");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -795,7 +781,6 @@ on_listview_odd_row_color_set          (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_odd_row");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -804,7 +789,6 @@ on_listview_selected_row_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_selection");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -813,7 +797,6 @@ on_listview_text_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_text");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -823,7 +806,6 @@ on_listview_selected_text_color_set    (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_selected_text");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -832,7 +814,6 @@ on_listview_cursor_color_set           (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_cursor");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -841,7 +822,6 @@ on_listview_playing_text_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_playing_text");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -850,7 +830,6 @@ on_listview_group_text_color_set       (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_group_text");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     gtk_widget_queue_draw (mainwin);
 }
@@ -862,7 +841,6 @@ on_listview_group_text_font_set        (GtkFontButton   *fontbutton,
     deadbeef->conf_set_str ("gtkui.font.listview_group_text", gtk_font_button_get_font_name (fontbutton));
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     gtk_widget_queue_draw (mainwin);
 }
@@ -874,7 +852,6 @@ on_listview_text_font_set              (GtkFontButton   *fontbutton,
     deadbeef->conf_set_str ("gtkui.font.listview_text", gtk_font_button_get_font_name (fontbutton));
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     gtk_widget_queue_draw (mainwin);
 }
@@ -886,7 +863,6 @@ on_listview_playing_text_bold_toggled  (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.embolden_current_track", active);
     gtkui_embolden_current_track = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -897,7 +873,6 @@ on_listview_playing_text_italic_toggled (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.italic_current_track", active);
     gtkui_italic_current_track = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -908,7 +883,6 @@ on_listview_selected_text_bold_toggled (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.embolden_selected_tracks", active);
     gtkui_embolden_selected_tracks = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -919,7 +893,6 @@ on_listview_selected_text_italic_toggled (GtkToggleButton *togglebutton,
     int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
     deadbeef->conf_set_int ("gtkui.italic_selected_tracks", active);
     gtkui_italic_selected_tracks = active;
-    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
 }
 
@@ -928,7 +901,6 @@ on_listview_column_text_color_set      (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
     color_set_helper (colorbutton, user_data, "gtkui.color.listview_column_text");
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
@@ -939,7 +911,6 @@ on_listview_column_text_font_set       (GtkFontButton   *fontbutton,
     deadbeef->conf_set_str ("gtkui.font.listview_column_text", gtk_font_button_get_font_name (fontbutton));
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
-    playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -443,6 +443,18 @@ search_selection_changed (DdbListview *ps, DdbListviewIter it, int idx) {
     pl_common_selection_changed (ps, PL_SEARCH, it);
 }
 
+static void search_delete_selected (void) {
+    ddb_playlist_t *plt = deadbeef->plt_get_curr ();
+    if (plt) {
+        for (DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH); it; it = deadbeef->pl_get_next (it, PL_SEARCH)) {
+            if (deadbeef->pl_is_selected (it)) {
+                deadbeef->plt_remove_item (plt, it);
+            }
+        }
+        deadbeef->plt_unref (plt);
+    }
+}
+
 static void
 search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int x, int y, int width, int height)
 {
@@ -492,7 +504,7 @@ static DdbListviewBinding search_binding = {
     .selection_changed = search_selection_changed,
     .header_context_menu = pl_common_header_context_menu,
     .list_context_menu = pl_common_list_context_menu,
-    .delete_selected = pl_common_delete_selected,
+    .delete_selected = search_delete_selected,
     .modification_idx = gtkui_get_curr_playlist_mod,
 };
 

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -111,12 +111,16 @@ search_refresh (void) {
 
 void
 search_start (void) {
-    ddb_listview_lock_columns (DDB_LISTVIEW (lookup_widget (searchwin, "searchlist")), 1);
+    DdbListview *listview = DDB_LISTVIEW(lookup_widget(searchwin, "searchlist"));
+    ddb_listview_lock_columns(listview, 1);
     wingeom_restore (searchwin, "searchwin", -1, -1, 450, 150, 0);
-    gtk_entry_set_text (GTK_ENTRY (lookup_widget (searchwin, "searchentry")), "");
-    gtk_widget_grab_focus (lookup_widget (searchwin, "searchentry"));
+    GtkWidget *entry = lookup_widget (searchwin, "searchentry");
+    gtk_entry_set_text(GTK_ENTRY(entry), "");
+    gtk_widget_grab_focus(entry);
     gtk_widget_show (searchwin);
     gtk_window_present (GTK_WINDOW (searchwin));
+    ddb_listview_list_setup (listview, 0);
+    ddb_listview_refresh(listview, DDB_REFRESH_CONFIG);
     g_idle_add (unlock_search_columns_cb, NULL);
     search_refresh ();
     main_refresh ();
@@ -400,5 +404,4 @@ search_playlist_init (GtkWidget *widget) {
     deadbeef->conf_unlock ();
     listview->group_title_bytecode = deadbeef->tf_compile (listview->group_format);
     window_title_bytecode = deadbeef->tf_compile (_("Search [(%list_total% results)]"));
-    ddb_listview_set_vscroll (listview, 0);
 }

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -275,19 +275,8 @@ search_col_sort (int col, int sort_order, void *user_data) {
 }
 
 static void
-search_groups_changed (DdbListview *listview, const char *format) {
-    if (!format) {
-        return;
-    }
-    if (listview->group_format) {
-        free (listview->group_format);
-    }
-    if (listview->group_title_bytecode) {
-        free (listview->group_title_bytecode);
-    }
+search_groups_changed (const char *format) {
     deadbeef->conf_set_str ("gtkui.search.group_by", format);
-    listview->group_format = strdup (format);
-    listview->group_title_bytecode = deadbeef->tf_compile (listview->group_format);
 }
 
 static int lock_column_config = 0;
@@ -295,7 +284,7 @@ static int lock_column_config = 0;
 static void
 search_columns_changed (DdbListview *listview) {
     if (!lock_column_config) {
-        rewrite_column_config (listview, "gtkui.columns.search");
+        pl_common_rewrite_column_config (listview, "gtkui.columns.search");
     }
 }
 
@@ -311,28 +300,13 @@ search_selection_changed (DdbListview *ps, DdbListviewIter it, int idx) {
 }
 
 static void
-search_delete_selected (void) {
-    deadbeef->pl_delete_selected ();
-    main_refresh ();
-    search_refresh ();
-}
-
-static void
-search_header_context_menu (DdbListview *ps, int column) {
-    GtkWidget *menu = create_headermenu (ps, 1);
-    set_last_playlist_cm (ps); // playlist ptr for context menu
-    set_active_column_cm (column);
-    gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, ps, 3, gtk_get_current_event_time());
-}
-
-static void
-search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height)
+search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int x, int y, int width, int height)
 {
-    draw_column_data (listview, cr, it, idx, column, PL_SEARCH, x, y, width, height);
+    pl_common_draw_column_data (listview, cr, it, idx, column, PL_SEARCH, x, y, width, height);
 }
 
 static void
-search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height)
+search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int x, int y, int width, int height)
 {
     pl_common_draw_group_title (listview, drawable, it, PL_SEARCH, x, y, width, height);
 }
@@ -363,11 +337,11 @@ static DdbListviewBinding search_binding = {
     .external_drag_n_drop = NULL,
 
     .draw_column_data = search_draw_column_data,
-    .draw_album_art = draw_album_art,
+    .draw_album_art = pl_common_draw_album_art,
     .draw_group_title = search_draw_group_title,
 
     // columns
-    .is_album_art_column = is_album_art_column,
+    .is_album_art_column = pl_common_is_album_art_column,
     .col_sort = search_col_sort,
     .columns_changed = search_columns_changed,
     .col_free_user_data = pl_common_free_col_info,
@@ -375,9 +349,9 @@ static DdbListviewBinding search_binding = {
     // callbacks
     .handle_doubleclick = search_handle_doubleclick,
     .selection_changed = search_selection_changed,
-    .header_context_menu = search_header_context_menu,
-    .list_context_menu = list_context_menu,
-    .delete_selected = search_delete_selected,
+    .header_context_menu = pl_common_header_context_menu,
+    .list_context_menu = pl_common_list_context_menu,
+    .delete_selected = pl_common_delete_selected,
     .modification_idx = gtkui_get_curr_playlist_mod,
 };
 
@@ -391,11 +365,11 @@ search_playlist_init (GtkWidget *widget) {
     ddb_listview_set_binding (listview, &search_binding);
     lock_column_config = 1;
     // create default set of columns
-    if (load_column_config (listview, "gtkui.columns.search") < 0) {
-        add_column_helper (listview, _("Artist / Album"), 150, -1, "%artist% - %album%", 0);
-        add_column_helper (listview, _("Track No"), 50, -1, "%track number%", 1);
-        add_column_helper (listview, _("Title"), 150, -1, "%title%", 0);
-        add_column_helper (listview, _("Duration"), 50, -1, "%length%", 0);
+    if (pl_common_load_column_config (listview, "gtkui.columns.search") < 0) {
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, "%artist% - %album%", 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, -1, "%track number%", 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, -1, "%title%", 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, -1, "%length%", 0);
     }
     lock_column_config = 0;
 

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -366,10 +366,10 @@ search_playlist_init (GtkWidget *widget) {
     lock_column_config = 1;
     // create default set of columns
     if (pl_common_load_column_config (listview, "gtkui.columns.search") < 0) {
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, "%artist% - %album%", 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, "%track number%", 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, "%title%", 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, "%length%", 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, 0);
     }
     lock_column_config = 0;
 

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -137,57 +137,6 @@ search_redraw (void) {
     }
 }
 
-///////// searchwin header handlers
-
-gboolean
-on_searchheader_button_press_event     (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data)
-{
-
-  return FALSE;
-}
-
-
-gboolean
-on_searchheader_button_release_event   (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data)
-{
-
-  return FALSE;
-}
-
-
-gboolean
-on_searchheader_configure_event        (GtkWidget       *widget,
-                                        GdkEventConfigure *event,
-                                        gpointer         user_data)
-{
-    return FALSE;
-}
-
-
-gboolean
-on_searchheader_expose_event           (GtkWidget       *widget,
-                                        GdkEventExpose  *event,
-                                        gpointer         user_data)
-{
-
-  return FALSE;
-}
-
-
-gboolean
-on_searchheader_motion_notify_event    (GtkWidget       *widget,
-                                        GdkEventMotion  *event,
-                                        gpointer         user_data)
-{
-
-  return FALSE;
-}
-
-
 ///////// searchwin playlist navigation and rendering
 
 void

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -243,7 +243,22 @@ search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
             }
             break;
         case DB_EV_CONFIGCHANGED:
-            g_idle_add(configchanged_cb, listview);
+            if (ctx) {
+                char *conf_str = (char *)ctx;
+                if (gtkui_listview_override_conf(conf_str) || gtkui_listview_font_conf(conf_str)) {
+                    g_idle_add(configchanged_cb, listview);
+                }
+                else if (gtkui_listview_colors_conf(conf_str)) {
+                    g_idle_add (list_redraw_cb, listview);
+                    g_idle_add (header_redraw_cb, listview);
+                }
+                else if (gtkui_listview_font_style_conf(conf_str) || !strcmp (conf_str, "playlist.pin.groups")) {
+                    g_idle_add (list_redraw_cb, listview);
+                }
+                else if (gtkui_tabstrip_override_conf(conf_str) || gtkui_tabstrip_colors_conf(conf_str)) {
+                    g_idle_add (header_redraw_cb, listview);
+                }
+            }
             break;
         case DB_EV_PLAYLISTSWITCHED:
             g_idle_add(refresh_cb, NULL);

--- a/plugins/gtkui/search.h
+++ b/plugins/gtkui/search.h
@@ -26,9 +26,6 @@
 
 #include "ddblistview.h"
 
-extern struct playItem_s *search_current;
-extern int search_count;
-
 void
 search_start (void);
 

--- a/plugins/gtkui/search.h
+++ b/plugins/gtkui/search.h
@@ -32,9 +32,6 @@ search_start (void);
 void
 search_destroy (void);
 
-void
-search_redraw (DB_playItem_t *it);
-
 int
 search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2);
 

--- a/plugins/gtkui/search.h
+++ b/plugins/gtkui/search.h
@@ -32,15 +32,11 @@ search_start (void);
 void
 search_destroy (void);
 
-// should be called whenever playlist was changed
 void
-search_refresh (void);
-
-void
-search_redraw (void);
+search_redraw (DB_playItem_t *it);
 
 int
-search_get_idx (DdbListviewIter it);
+search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2);
 
 void
 search_playlist_init (GtkWidget *widget);

--- a/plugins/gtkui/trkproperties.c
+++ b/plugins/gtkui/trkproperties.c
@@ -587,8 +587,6 @@ write_finished_cb (void *ctx) {
         deadbeef->plt_modified (plt);
         deadbeef->plt_unref (plt);
     }
-    main_refresh ();
-    search_refresh ();
     trkproperties_modified = 0;
     show_track_properties_dlg (last_ctx);
 
@@ -700,11 +698,16 @@ on_write_tags_clicked                  (GtkButton       *button,
     gtk_tree_model_foreach (model, set_metadata_cb, NULL);
     deadbeef->pl_unlock ();
 
-    for (int i = 0; i < numtracks; i++) {
-        ddb_event_track_t *ev = (ddb_event_track_t *)deadbeef->event_alloc (DB_EV_TRACKINFOCHANGED);
-        ev->track = tracks[i];
-        deadbeef->pl_item_ref (ev->track);
-        deadbeef->event_send ((ddb_event_t*)ev, 0, 0);
+    if (numtracks > 25) {
+        deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    }
+    else {
+        for (int i = 0; i < numtracks; i++) {
+            ddb_event_track_t *ev = (ddb_event_track_t *)deadbeef->event_alloc (DB_EV_TRACKINFOCHANGED);
+            ev->track = tracks[i];
+            deadbeef->pl_item_ref (ev->track);
+            deadbeef->event_send ((ddb_event_t*)ev, 0, 0);
+        }
     }
 
     progress_aborted = 0;

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -2072,11 +2072,9 @@ paused_cb (gpointer data) {
 static gboolean
 config_changed_cb (gpointer data) {
     DdbListview *p = DDB_LISTVIEW (data);
-    ddb_listview_update_fonts (p);
-    ddb_listview_header_update_fonts (p);
     ddb_listview_lock_columns (p, 0);
     ddb_listview_clear_sort (p);
-    ddb_listview_refresh (DDB_LISTVIEW (p), DDB_REFRESH_LIST | DDB_REFRESH_VSCROLL);
+    ddb_listview_refresh (DDB_LISTVIEW(data), DDB_REFRESH_COLUMNS | DDB_REFRESH_LIST | DDB_REFRESH_CONFIG);
     return FALSE;
 }
 

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -2064,7 +2064,7 @@ playlist_config_changed_cb (gpointer data) {
 
 static gboolean
 playlist_sort_reset_cb (gpointer data) {
-    ddb_listview_clear_sort (DDB_LISTVIEW(data));
+    ddb_listview_col_sort (DDB_LISTVIEW(data));
     return FALSE;
 }
 

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -2243,7 +2243,7 @@ w_tabbed_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, ui
     w_playlist_t *tp = (w_playlist_t *)w;
     switch (id) {
     case DB_EV_SONGCHANGED:
-        g_idle_add (redraw_queued_tracks_cb, tp->list);
+    {
         ddb_event_trackchange_t *ev = (ddb_event_trackchange_t *)ctx;
         struct fromto_t *ft = malloc (sizeof (struct fromto_t));
         ft->from = ev->from;
@@ -2257,6 +2257,7 @@ w_tabbed_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, ui
         ft->w = w;
         g_idle_add (songchanged_cb, ft);
         break;
+    }
     case DB_EV_TRACKINFOCHANGED:
         {
             ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
@@ -2308,7 +2309,7 @@ w_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, uint32_t 
     w_playlist_t *p = (w_playlist_t *)w;
     switch (id) {
     case DB_EV_SONGCHANGED:
-        g_idle_add (redraw_queued_tracks_cb, p->list);
+    {
         ddb_event_trackchange_t *ev = (ddb_event_trackchange_t *)ctx;
         struct fromto_t *ft = malloc (sizeof (struct fromto_t));
         ft->from = ev->from;
@@ -2322,6 +2323,7 @@ w_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, uint32_t 
         ft->w = w;
         g_idle_add (songchanged_cb, ft);
         break;
+    }
     case DB_EV_TRACKINFOCHANGED:
         {
             ddb_event_track_t *ev = (ddb_event_track_t *)ctx;

--- a/plugins/hotkeys/actionhandlers.c
+++ b/plugins/hotkeys/actionhandlers.c
@@ -584,13 +584,12 @@ action_add_to_playqueue_handler (DB_plugin_action_t *act, int ctx) {
     DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
     while (it) {
         if (ctx == DDB_ACTION_CTX_PLAYLIST || (ctx == DDB_ACTION_CTX_SELECTION && deadbeef->pl_is_selected (it))) {
-            deadbeef->pl_playqueue_push (it);
+            deadbeef->playqueue_push (it);
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
         it = next;
     }
-    deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
     return 0;
 }
 
@@ -599,13 +598,12 @@ action_remove_from_playqueue_handler (DB_plugin_action_t *act, int ctx) {
     DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
     while (it) {
         if (ctx == DDB_ACTION_CTX_PLAYLIST || (ctx == DDB_ACTION_CTX_SELECTION && deadbeef->pl_is_selected (it))) {
-            deadbeef->pl_playqueue_remove (it);
+            deadbeef->playqueue_remove (it);
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
         it = next;
     }
-    deadbeef->sendmessage (DB_EV_PLAYLIST_REFRESH, 0, 0, 0);
     return 0;
 }
 


### PR DESCRIPTION
Fix playlist search window responses to events, and improve playlist-related messaging in general.
Fixes #1367, #1357, #1354, and #1330, as well as various problems with cursor following in background tabs and syncing with the search window.
Also fixes column adding and editing so that the new formats all match up.
Removes a number of obsolete declarations and some obsolete functions, and fixes many deprecation warnings from GTK and Deadbeef.