### PR TITLE
gtkui: add listview tooltips for columns and headers which are truncated

### DIFF
--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -93,7 +93,7 @@ typedef struct {
 
     void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int x, int y, int width, int height);
     void (*draw_album_art) (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
-    void (*draw_column_data) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int idx, int column, int x, int y, int width, int height);
+    void (*draw_column_data) (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height);
 
     // cols
     int (*is_album_art_column) (void *user_data);
@@ -214,8 +214,6 @@ void
 ddb_listview_set_binding (DdbListview *listview, DdbListviewBinding *binding);
 void
 ddb_listview_draw_row (DdbListview *listview, int idx, DdbListviewIter iter);
-DdbListviewIter
-ddb_listview_get_iter_from_coord (DdbListview *listview, int x, int y);
 int
 ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state);
 void
@@ -254,7 +252,6 @@ enum {
     DDB_LIST_CHANGED    = 16,
     DDB_REFRESH_CONFIG  = 32,
 };
-
 
 void
 ddb_listview_refresh (DdbListview *listview, uint32_t flags);

--- a/plugins/gtkui/drawing.h
+++ b/plugins/gtkui/drawing.h
@@ -91,6 +91,11 @@ draw_text_with_colors (drawctx_t *ctx, float x, float y, int width, int align, c
 
 void
 draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h);
+int
+draw_is_ellipsized (drawctx_t *ctx);
+
+const char *
+draw_get_text (drawctx_t *ctx);
 
 int
 draw_get_listview_rowheight (drawctx_t *ctx);

--- a/plugins/gtkui/gdkdrawing.c
+++ b/plugins/gtkui/gdkdrawing.c
@@ -242,6 +242,16 @@ draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h
 }
 
 int
+draw_is_ellipsized (drawctx_t *ctx) {
+    return pango_layout_is_ellipsized (ctx->pangolayout);
+}
+
+const char *
+draw_get_text (drawctx_t *ctx) {
+    return pango_layout_get_text (ctx->pangolayout);
+}
+
+int
 draw_get_listview_rowheight (drawctx_t *ctx) {
     PangoFontDescription *font_desc = pango_font_description_copy (pango_layout_get_font_description (ctx->pangolayout));
     PangoFontMetrics *metrics = pango_context_get_metrics (ctx->pangoctx,

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -44,7 +44,7 @@ void
 pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
 
 void
-pl_common_draw_column_data (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int idx, int column, int iter, int x, int y, int width, int height);
+pl_common_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int iter, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height);
 
 void
 pl_common_list_context_menu (DdbListview *listview, DdbListviewIter it, int idx);

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -472,9 +472,9 @@ static void search_delete_selected (void) {
 }
 
 static void
-search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int column, int x, int y, int width, int height)
+search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height)
 {
-    pl_common_draw_column_data (listview, cr, it, idx, column, PL_SEARCH, x, y, width, height);
+    pl_common_draw_column_data (listview, cr, it, idx, PL_SEARCH, align, user_data, fg_clr, x, y, width, height);
 }
 
 static void


### PR DESCRIPTION
Common practice for data lists with text content that is truncated is to provide a tooltip showing the entire text.  This PR does that both for the listview rows and for the column headers.

Previous code for potentially showing the track URI as the tooltip, in response to a dummy config value and only on the main playlist, is completely removed.