### PR TITLE
gtkui: make DB_EV_FOCUS_SELECTION work properly again, fix some cursor and scroll edge cases

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -428,6 +428,10 @@ enum {
     DB_EV_TRACKFOCUSCURRENT = 1006, // user wants to highlight/find the current playing track
 #endif
 
+#if (DDB_API_LEVEL >= 9)
+    DB_EV_CURSOR_MOVED = 1007, // for synchronising listviews, p1 = playlist iter sending the message
+#endif
+
     DB_EV_MAX
 };
 

--- a/messagepump.c
+++ b/messagepump.c
@@ -154,6 +154,7 @@ messagepump_event_alloc (uint32_t id) {
     case DB_EV_SONGSTARTED:
     case DB_EV_SONGFINISHED:
     case DB_EV_TRACKINFOCHANGED:
+    case DB_EV_CURSOR_MOVED:
         sz = sizeof (ddb_event_track_t);
         break;
     case DB_EV_SEEKED:
@@ -185,6 +186,7 @@ messagepump_event_free (ddb_event_t *ev) {
     case DB_EV_SONGSTARTED:
     case DB_EV_SONGFINISHED:
     case DB_EV_TRACKINFOCHANGED:
+    case DB_EV_CURSOR_MOVED:
         {
             ddb_event_track_t *tc = (ddb_event_track_t*)ev;
             if (tc->track) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1776,6 +1776,8 @@ ddb_listview_list_mouse1_pressed (DdbListview *ps, int state, int ex, int ey, Gd
         }
     }
 
+    gtkui_listview_busy = 1;
+
     // set cursor
     int prev = cursor;
     if (pick_ctx.type != PICK_EMPTY_SPACE
@@ -1859,6 +1861,7 @@ ddb_listview_list_mouse1_pressed (DdbListview *ps, int state, int ex, int ey, Gd
 
 void
 ddb_listview_list_mouse1_released (DdbListview *ps, int state, int ex, int ey, double time) {
+    gtkui_listview_busy = 0;
 
 #ifndef __APPLE__
     int selmask = GDK_CONTROL_MASK;
@@ -2997,11 +3000,6 @@ ddb_listview_scroll_to (DdbListview *listview, int pos) {
     if (pos < listview->scrollpos || pos + listview->rowheight >= listview->scrollpos + listview->list_height) {
         gtk_range_set_value (GTK_RANGE (listview->scrollbar), pos - listview->list_height/2);
     }
-}
-
-int
-ddb_listview_is_scrolling (DdbListview *listview) {
-    return listview->dragwait || listview->areaselect || listview->drag_motion_y != -1;
 }
 
 /////// column management code

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1529,7 +1529,7 @@ ddb_listview_toggle_group_selection (DdbListview *listview, DdbListviewGroup *gr
     ddb_listview_select_group (listview, grp, item_idx, deselect);
 }
 
-static void
+void
 ddb_listview_select_single (DdbListview *ps, int sel) {
     deadbeef->pl_lock ();
     ddb_listview_deselect_all(ps);
@@ -1560,12 +1560,6 @@ ddb_listview_update_cursor (DdbListview *ps, int cursor)
     }
 }
 
-void
-ddb_listview_set_cursor (DdbListview *listview, int cursor) {
-    ddb_listview_update_cursor (listview, cursor);
-    ddb_listview_select_single (listview, cursor);
-}
-
 struct set_cursor_t {
     int cursor;
     DdbListview *pl;
@@ -1574,7 +1568,8 @@ struct set_cursor_t {
 static gboolean
 set_cursor_and_scroll_cb (gpointer data) {
     struct set_cursor_t *sc = (struct set_cursor_t *)data;
-    ddb_listview_set_cursor (sc->pl, sc->cursor);
+    ddb_listview_update_cursor (sc->pl, sc->cursor);
+    ddb_listview_select_single (sc->pl, sc->cursor);
 
     int cursor_scroll = ddb_listview_get_row_pos (sc->pl, sc->cursor);
     int newscroll = sc->pl->scrollpos;
@@ -3002,21 +2997,6 @@ ddb_listview_scroll_to (DdbListview *listview, int pos) {
     if (pos < listview->scrollpos || pos + listview->rowheight >= listview->scrollpos + listview->list_height) {
         gtk_range_set_value (GTK_RANGE (listview->scrollbar), pos - listview->list_height/2);
     }
-}
-
-void
-ddb_listview_track_focus (DdbListview *listview, DdbListviewIter it) {
-    ddb_playlist_t *plt = deadbeef->pl_get_playlist (it);
-    if (plt) {
-        deadbeef->plt_set_curr (plt);
-        int cursor = listview->binding->get_idx (it);
-        if (cursor != -1) {
-            ddb_listview_scroll_to (listview, cursor);
-            ddb_listview_set_cursor (listview, cursor);
-        }
-        deadbeef->plt_unref (plt);
-    }
-    deadbeef->pl_item_unref (it);
 }
 
 int

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -217,11 +217,9 @@ ddb_listview_draw_row (DdbListview *listview, int idx, DdbListviewIter iter);
 int
 ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state);
 void
-ddb_listview_set_cursor (DdbListview *pl, int cursor);
+ddb_listview_select_single (DdbListview *listview, int sel);
 void
 ddb_listview_scroll_to (DdbListview *listview, int rowpos);
-void
-ddb_listview_track_focus (DdbListview *listview, DdbListviewIter it);
 int
 ddb_listview_list_setup (DdbListview *listview, int scroll_to);
 int

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -223,8 +223,6 @@ ddb_listview_scroll_to (DdbListview *listview, int rowpos);
 int
 ddb_listview_list_setup (DdbListview *listview, int scroll_to);
 int
-ddb_listview_is_scrolling (DdbListview *listview);
-int
 ddb_listview_column_get_count (DdbListview *listview);
 void
 ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -54,6 +54,7 @@ extern int gtkui_tabstrip_italic_playing;
 struct _GSList;
 
 extern int gtkui_groups_pinned;
+extern int gtkui_listview_busy;
 
 extern const char *gtkui_default_titlebar_playing;
 extern const char *gtkui_default_titlebar_stopped;

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -62,7 +62,12 @@ main_get_cursor (void) {
 static void
 main_set_cursor (int cursor) {
     deadbeef->pl_set_cursor (PL_MAIN, cursor);
-    deadbeef->sendmessage (DB_EV_FOCUS_SELECTION, 0, cursor, PL_MAIN);
+    DB_playItem_t *it = deadbeef->pl_get_for_idx (cursor);
+    if (it) {
+        ddb_event_track_t *event = (ddb_event_track_t *)deadbeef->event_alloc(DB_EV_CURSOR_MOVED);
+        event->track = it;
+        deadbeef->event_send ((ddb_event_t *)event, PL_MAIN, 0);
+    }
 }
 
 static DdbListviewIter main_head (void) {

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1668,7 +1668,7 @@ pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it) {
     if (it) {
         ddb_event_track_t *ev = (ddb_event_track_t *)deadbeef->event_alloc(DB_EV_TRACKINFOCHANGED);
         ev->track = it;
-        ps->binding->ref(ev->track);
+        deadbeef->pl_item_ref(ev->track);
         deadbeef->event_send((ddb_event_t *)ev, DDB_PLAYLIST_CHANGE_SELECTION, iter);
     }
     else {

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -76,11 +76,13 @@ search_process (DdbListview *listview, ddb_playlist_t *plt) {
     deadbeef->plt_search_process2 (plt, text, 0);
     ddb_listview_col_sort (listview);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SEARCHRESULT, 0);
+
     int row = deadbeef->pl_get_cursor (PL_SEARCH);
     if (row >= deadbeef->pl_getcount (PL_SEARCH)) {
         deadbeef->pl_set_cursor (PL_SEARCH, deadbeef->pl_getcount (PL_SEARCH) - 1);
     }
-    ddb_listview_refresh (listview, DDB_REFRESH_LIST | DDB_LIST_CHANGED);
+    ddb_listview_list_setup (listview, listview->scrollpos);
+    ddb_listview_refresh (listview, DDB_REFRESH_LIST);
 
     char title[1024] = "";
     ddb_tf_context_t ctx = {
@@ -90,6 +92,7 @@ search_process (DdbListview *listview, ddb_playlist_t *plt) {
     };
     deadbeef->tf_eval (&ctx, window_title_bytecode, title, sizeof (title));
     gtk_window_set_title (GTK_WINDOW (searchwin), title);
+
 }
 
 static gboolean
@@ -108,9 +111,6 @@ search_start_cb (gpointer p) {
         wingeom_restore (searchwin, "searchwin", -1, -1, 450, 150, 0);
         gtk_widget_show (searchwin);
         gtk_entry_set_text (GTK_ENTRY (entry), "");
-        if (!ddb_listview_list_setup (listview, 0)) {
-            return TRUE;
-        }
         ddb_listview_refresh (listview, DDB_REFRESH_CONFIG);
     }
     gtk_editable_select_region (GTK_EDITABLE (entry), 0, -1);
@@ -138,6 +138,13 @@ search_destroy (void) {
     }
 }
 
+static DB_playItem_t *
+next_playitem (DB_playItem_t *it) {
+    DB_playItem_t *next = deadbeef->pl_get_next (it, PL_SEARCH);
+    deadbeef->pl_item_unref (it);
+    return next;
+}
+
 static gboolean
 paused_cb (gpointer p) {
     DB_playItem_t *it = deadbeef->streamer_get_playing_track();
@@ -152,7 +159,7 @@ paused_cb (gpointer p) {
 }
 
 static gboolean
-redraw_row_cb (gpointer p) {
+row_redraw_cb (gpointer p) {
     DB_playItem_t *it = (DB_playItem_t *)p;
     DdbListview *listview = playlist_visible();
     if (listview) {
@@ -178,27 +185,89 @@ header_redraw_cb (gpointer p) {
 }
 
 static gboolean
-focus_selection_cb (gpointer p) {
+songstarted_cb (gpointer p) {
+    DB_playItem_t *it = p;
     DdbListview *listview = playlist_visible();
     if (listview) {
-        int cursor = deadbeef->pl_get_idx_of_iter (p, PL_SEARCH);
-        if (cursor != -1) {
-            deadbeef->pl_set_cursor (PL_SEARCH, cursor);
-            ddb_listview_scroll_to (listview, cursor);
+        int idx = deadbeef->pl_get_idx_of_iter (it, PL_SEARCH);
+        if (idx != -1) {
+            if (!!ddb_listview_is_scrolling (listview)) {
+                if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1)) {
+                    ddb_listview_select_single (listview, idx);
+                    deadbeef->pl_set_cursor (PL_SEARCH, idx);
+                }
+                if (deadbeef->conf_get_int ("playlist.scroll.followplayback", 1)) {
+                    ddb_listview_scroll_to (listview, idx);
+                }
+            }
+            ddb_listview_draw_row (listview, idx, it);
         }
+    }
+    deadbeef->pl_item_unref (it);
+    return FALSE;
+}
+
+static void
+set_cursor (DdbListview *listview, DB_playItem_t *it) {
+    int new_cursor = deadbeef->pl_get_idx_of_iter (it, PL_SEARCH);
+    if (new_cursor != -1) {
+        int cursor = deadbeef->pl_get_cursor (PL_SEARCH);
+        if (new_cursor != cursor) {
+            deadbeef->pl_set_cursor (PL_SEARCH, new_cursor);
+            ddb_listview_draw_row (listview, new_cursor, NULL);
+            if (cursor != -1) {
+                ddb_listview_draw_row (listview, cursor, NULL);
+            }
+        }
+        ddb_listview_scroll_to (listview, new_cursor);
+    }
+}
+
+static gboolean
+cursor_moved_cb (gpointer p) {
+    DdbListview *listview = playlist_visible();
+    if (listview) {
+        set_cursor (listview, p);
     }
     deadbeef->pl_item_unref (p);
     return FALSE;
 }
 
 static gboolean
-trackfocus_cb (gpointer data) {
-    deadbeef->pl_lock ();
-    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
-    if (it) {
-        ddb_listview_track_focus (DDB_LISTVIEW (data), it);
+focus_selection_cb (gpointer data) {
+    DdbListview *listview = playlist_visible();
+    if (listview) {
+        deadbeef->pl_lock ();
+        DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH);
+        while (it && !deadbeef->pl_is_selected (it)) {
+            it = next_playitem (it);
+        }
+        if (it) {
+            set_cursor (listview, it);
+            deadbeef->pl_item_unref (it);
+        }
+        deadbeef->pl_unlock ();
     }
-    deadbeef->pl_unlock ();
+    return FALSE;
+}
+
+static gboolean
+trackfocus_cb (gpointer p) {
+    DdbListview *listview = playlist_visible();
+    if (listview) {
+        deadbeef->pl_lock ();
+        DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
+        if (it) {
+            int idx = deadbeef->pl_get_idx_of_iter (it, PL_SEARCH);
+            if (idx != -1) {
+                ddb_listview_select_single (listview, idx);
+                deadbeef->pl_set_cursor (PL_SEARCH, idx);
+                ddb_listview_scroll_to (listview, idx);
+            }
+            deadbeef->pl_item_unref (it);
+        }
+        deadbeef->pl_unlock ();
+    }
     return FALSE;
 }
 
@@ -229,6 +298,14 @@ submit_refresh (void) {
     }
 }
 
+static gboolean
+playlistswitch_cb (void) {
+    DdbListview *listview = playlist_visible();
+    if (listview) {
+        ddb_listview_list_setup(listview, 0);
+    }
+}
+
 int
 search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
     DdbListview *listview = playlist_visible();
@@ -240,16 +317,21 @@ search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
         case DB_EV_PAUSED:
             g_idle_add(paused_cb, listview);
             break;
-        case DB_EV_SONGCHANGED:
+        case DB_EV_SONGFINISHED:
         {
-            ddb_event_trackchange_t *ev = (ddb_event_trackchange_t *)ctx;
-            if (ev->from) {
-                deadbeef->pl_item_ref(ev->from);
-                g_idle_add(redraw_row_cb, ev->from);
+            ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+            if (ev->track) {
+                deadbeef->pl_item_ref(ev->track);
+                g_idle_add(row_redraw_cb, ev->track);
             }
-            if (ev->to) {
-                deadbeef->pl_item_ref(ev->to);
-                g_idle_add(redraw_row_cb, ev->to);
+            break;
+        }
+        case DB_EV_SONGSTARTED:
+        {
+            ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+            if (ev->track) {
+                deadbeef->pl_item_ref(ev->track);
+                g_idle_add(songstarted_cb, ev->track);
             }
             break;
         }
@@ -258,7 +340,7 @@ search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
                 ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
                 if (ev->track) {
                     deadbeef->pl_item_ref (ev->track);
-                    g_idle_add(redraw_row_cb, ev->track);
+                    g_idle_add(row_redraw_cb, ev->track);
                 }
             }
             else if (p1 == DDB_PLAYLIST_CHANGE_CONTENT) {
@@ -274,16 +356,20 @@ search_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
             }
             break;
         case DB_EV_PLAYLISTSWITCHED:
-                submit_refresh();
-            break;
-        case DB_EV_TRACKFOCUSCURRENT:
-            g_idle_add (trackfocus_cb, listview);
+            submit_refresh();
             break;
         case DB_EV_FOCUS_SELECTION:
-            if (p2 != PL_SEARCH) {
-                DB_playItem_t *it = deadbeef->pl_get_for_idx_and_iter (p1, p2);
-                if (it) {
-                    g_idle_add (focus_selection_cb, it);
+            g_idle_add (focus_selection_cb, NULL);
+            break;
+        case DB_EV_TRACKFOCUSCURRENT:
+            g_idle_add (trackfocus_cb, NULL);
+            break;
+        case DB_EV_CURSOR_MOVED:
+            if (p1 != PL_SEARCH) {
+                ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+                if (ev->track) {
+                    deadbeef->pl_item_ref (ev->track);
+                    g_idle_add (cursor_moved_cb, ev->track);
                 }
             }
             break;
@@ -321,14 +407,18 @@ on_searchentry_changed                 (GtkEditable     *editable,
         if (plt) {
             deadbeef->plt_deselect_all (plt);
             search_process (listview, plt);
-            for (DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_SEARCH); it; it = deadbeef->pl_get_next (it, PL_SEARCH)) {
+            for (DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_SEARCH); it; it = next_playitem (it)) {
                 deadbeef->pl_set_selected (it, 1);
-                deadbeef->pl_item_unref (it);
             }
             deadbeef->plt_unref (plt);
         }
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
-        deadbeef->sendmessage(DB_EV_FOCUS_SELECTION, 0, 0, PL_SEARCH);
+        DB_playItem_t *head = deadbeef->pl_get_first (PL_SEARCH);
+        if (head) {
+            ddb_event_track_t *event = (ddb_event_track_t *)deadbeef->event_alloc(DB_EV_CURSOR_MOVED);
+            event->track = head;
+            deadbeef->event_send ((ddb_event_t *)event, PL_SEARCH, 0);
+        }
     }
 }
 
@@ -376,14 +466,10 @@ on_searchwin_window_state_event        (GtkWidget       *widget,
 static int
 search_get_sel_count (void) {
     int cnt = 0;
-    DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH);
-    while (it) {
+    for (DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH); it; it = next_playitem (it)) {
         if (deadbeef->pl_is_selected (it)) {
             cnt++;
         }
-        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_SEARCH);
-        deadbeef->pl_item_unref (it);
-        it = next;
     }
     return cnt;
 }
@@ -398,7 +484,12 @@ static int search_get_cursor (void) {
 
 static void search_set_cursor (int cursor) {
     deadbeef->pl_set_cursor (PL_SEARCH, cursor);
-    deadbeef->sendmessage (DB_EV_FOCUS_SELECTION, 0, cursor, PL_SEARCH);
+    DB_playItem_t *it = deadbeef->pl_get_for_idx_and_iter (cursor, PL_SEARCH);
+    if (it) {
+        ddb_event_track_t *event = (ddb_event_track_t *)deadbeef->event_alloc(DB_EV_CURSOR_MOVED);
+        event->track = it;
+        deadbeef->event_send ((ddb_event_t *)event, PL_SEARCH, 0);
+    }
 }
 
 static DdbListviewIter search_head (void) {
@@ -462,7 +553,7 @@ search_selection_changed (DdbListview *ps, DdbListviewIter it, int idx) {
 static void search_delete_selected (void) {
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();
     if (plt) {
-        for (DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH); it; it = deadbeef->pl_get_next (it, PL_SEARCH)) {
+        for (DB_playItem_t *it = deadbeef->pl_get_first (PL_SEARCH); it; it = next_playitem (it)) {
             if (deadbeef->pl_is_selected (it)) {
                 deadbeef->plt_remove_item (plt, it);
             }

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -191,7 +191,7 @@ songstarted_cb (gpointer p) {
     if (listview) {
         int idx = deadbeef->pl_get_idx_of_iter (it, PL_SEARCH);
         if (idx != -1) {
-            if (!!ddb_listview_is_scrolling (listview)) {
+            if (!gtkui_listview_busy) {
                 if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1)) {
                     ddb_listview_select_single (listview, idx);
                     deadbeef->pl_set_cursor (PL_SEARCH, idx);

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -2102,94 +2102,112 @@ playlist_setup_cb (gpointer data) {
             DB_playItem_t *it = deadbeef->pl_get_for_idx (cursor);
             if (it) {
                 deadbeef->pl_set_selected (it, 1);
-                if (scroll == -1) {
-                    ddb_listview_scroll_to (listview, cursor);
-                }
                 deadbeef->pl_item_unref (it);
             }
         }
         deadbeef->plt_unref (plt);
+
+        if (scroll < 0) {
+            ddb_listview_scroll_to (listview, scroll * -1);
+        }
 
         ddb_listview_refresh(listview, DDB_REFRESH_LIST);
     }
     return FALSE;
 }
 
-struct fromto_t {
-    DdbListview *listview;
-    DB_playItem_t *from;
-    DB_playItem_t *to;
-};
-
-static struct fromto_t *
-songchanged_fromto (DdbListview *listview, ddb_event_trackchange_t *ev) {
-    struct fromto_t *ft = malloc (sizeof (struct fromto_t));
-    ft->from = ev->from;
-    ft->to = ev->to;
-    if (ft->from) {
-        deadbeef->pl_item_ref (ft->from);
-    }
-    if (ft->to) {
-        deadbeef->pl_item_ref (ft->to);
-    }
-    ft->listview = listview;
-    return ft;
-}
-
 static gboolean
-songchanged_cb (gpointer data) {
-    struct fromto_t *ft = data;
-
-    if (ft->from) {
-        int idx = deadbeef->pl_get_idx_of (ft->from);
-        if (idx != -1) {
-            ddb_listview_draw_row (ft->listview, idx, ft->from);
-        }
-        deadbeef->pl_item_unref (ft->from);
+songfinished_cb (gpointer data) {
+    w_trackdata_t *d = data;
+    int idx = deadbeef->pl_get_idx_of (d->trk);
+    if (idx != -1) {
+        ddb_listview_draw_row (d->listview, idx, d->trk);
     }
-
-    if (ft->to) {
-        int idx = deadbeef->pl_get_idx_of (ft->to);
-        if (idx != -1) {
-            if (!ddb_listview_is_scrolling (ft->listview)) {
-                if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1)) {
-                    ddb_listview_set_cursor (ft->listview, idx);
-                }
-                if (deadbeef->conf_get_int ("playlist.scroll.followplayback", 1)) {
-                    ddb_listview_scroll_to (ft->listview, idx);
-                }
-                ddb_listview_draw_row (ft->listview, idx, ft->to);
-            }
-        }
-        deadbeef->pl_item_unref (ft->to);
-    }
-
-    free (ft);
-
+    deadbeef->pl_item_unref (d->trk);
+    free (data);
     return FALSE;
 }
 
 static gboolean
-trackfocus_cb (gpointer data) {
-    deadbeef->pl_lock ();
-    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
-    if (it) {
-        ddb_listview_track_focus (DDB_LISTVIEW (data), it);
+songstarted_cb (gpointer data) {
+    w_trackdata_t *d = data;
+    int idx = deadbeef->pl_get_idx_of (d->trk);
+    if (idx != -1) {
+        if (!ddb_listview_is_scrolling (d->listview)) {
+            if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1)) {
+                ddb_listview_select_single (d->listview, idx);
+                deadbeef->pl_set_cursor (PL_MAIN, idx);
+            }
+            if (deadbeef->conf_get_int ("playlist.scroll.followplayback", 1)) {
+                ddb_listview_scroll_to (d->listview, idx);
+            }
+        }
+        ddb_listview_draw_row (d->listview, idx, d->trk);
     }
-    deadbeef->pl_unlock ();
+    deadbeef->pl_item_unref (d->trk);
+    free (data);
+    return FALSE;
+}
+
+static void
+playlist_set_cursor (DdbListview *listview, DB_playItem_t *it) {
+    int new_cursor = deadbeef->pl_get_idx_of_iter (it, PL_MAIN);
+    if (new_cursor != -1) {
+        int cursor = deadbeef->pl_get_cursor (PL_MAIN);
+        if (new_cursor != cursor) {
+            deadbeef->pl_set_cursor (PL_MAIN, new_cursor);
+            ddb_listview_draw_row (listview, new_cursor, NULL);
+            if (cursor != -1) {
+                ddb_listview_draw_row (listview, cursor, NULL);
+            }
+        }
+        ddb_listview_scroll_to (listview, new_cursor);
+    }
+}
+
+static gboolean
+cursor_moved_cb (gpointer data) {
+    w_trackdata_t *d = data;
+    playlist_set_cursor (d->listview, d->trk);
+    deadbeef->pl_item_unref (d->trk);
+    free (data);
     return FALSE;
 }
 
 static gboolean
 focus_selection_cb (gpointer data) {
-    w_trackdata_t *d = data;
-    int cursor = deadbeef->pl_get_idx_of (d->trk);
-    if (cursor != -1) {
-        deadbeef->pl_set_cursor (PL_MAIN, cursor);
-        ddb_listview_scroll_to (d->listview, cursor);
+    DdbListview *listview = data;
+    deadbeef->pl_lock ();
+    DB_playItem_t *it = deadbeef->pl_get_first (PL_MAIN);
+    while (it && !deadbeef->pl_is_selected (it)) {
+        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+        deadbeef->pl_item_unref (it);
+        it = next;
     }
-    deadbeef->pl_item_unref (d->trk);
-    free (d);
+    if (it) {
+        playlist_set_cursor (listview, it);
+        deadbeef->pl_item_unref (it);
+    }
+    deadbeef->pl_unlock ();
+    return FALSE;
+}
+
+// This only actually does anything if the track is in the current playlist
+// Otherwise gtkui.c will handle it and send a PLAYLISTSWITCHED message
+static gboolean
+trackfocus_cb (gpointer data) {
+    deadbeef->pl_lock ();
+    DB_playItem_t *it = deadbeef->streamer_get_playing_track ();
+    if (it) {
+        int cursor = deadbeef->pl_get_idx_of (it);
+        if (cursor != -1) {
+            ddb_listview_select_single (data, cursor);
+            deadbeef->pl_set_cursor (PL_MAIN, cursor);
+            ddb_listview_scroll_to (data, cursor);
+        }
+        deadbeef->pl_item_unref (it);
+    }
+    deadbeef->pl_unlock ();
     return FALSE;
 }
 
@@ -2200,9 +2218,22 @@ w_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, uint32_t 
     case DB_EV_PAUSED:
         g_idle_add (paused_cb, p->list);
         break;
-    case DB_EV_SONGCHANGED:
-        g_idle_add (songchanged_cb, songchanged_fromto(p->list, (ddb_event_trackchange_t *)ctx));
+    case DB_EV_SONGFINISHED:
+    {
+        ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+        if (ev->track) {
+            g_idle_add (songfinished_cb, playlist_trackdata(p->list, ev->track));
+        }
         break;
+    }
+    case DB_EV_SONGSTARTED:
+    {
+        ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+        if (ev->track) {
+            g_idle_add (songstarted_cb, playlist_trackdata(p->list, ev->track));
+        }
+        break;
+    }
     case DB_EV_TRACKINFOCHANGED:
         if (p1 == DDB_PLAYLIST_CHANGE_CONTENT || p1 == DDB_PLAYLIST_CHANGE_PLAYQUEUE) {
             g_idle_add (playlist_sort_reset_cb, p->list);
@@ -2227,15 +2258,17 @@ w_playlist_message (ddb_gtkui_widget_t *w, uint32_t id, uintptr_t ctx, uint32_t 
     case DB_EV_PLAYLISTSWITCHED:
         g_idle_add (playlist_setup_cb, p->list);
         break;
+    case DB_EV_FOCUS_SELECTION:
+        g_idle_add (focus_selection_cb, p->list);
+        break;
     case DB_EV_TRACKFOCUSCURRENT:
         g_idle_add (trackfocus_cb, p->list);
         break;
-    case DB_EV_FOCUS_SELECTION:
-        if (p2 != PL_MAIN) {
-            DB_playItem_t *it = deadbeef->pl_get_for_idx_and_iter (p1, p2);
-            if (it) {
-                g_idle_add (focus_selection_cb, playlist_trackdata(p->list, it));
-                deadbeef->pl_item_unref (it);
+    case DB_EV_CURSOR_MOVED:
+        if (p1 != PL_MAIN) {
+            ddb_event_track_t *ev = (ddb_event_track_t *)ctx;
+            if (ev->track) {
+                g_idle_add (cursor_moved_cb, playlist_trackdata(p->list, ev->track));
             }
         }
         break;

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -2128,12 +2128,13 @@ songfinished_cb (gpointer data) {
     return FALSE;
 }
 
+// This only actually does anything if the track is in the current playlist, otherwise gtkui.c will handle it
 static gboolean
 songstarted_cb (gpointer data) {
     w_trackdata_t *d = data;
     int idx = deadbeef->pl_get_idx_of (d->trk);
     if (idx != -1) {
-        if (!ddb_listview_is_scrolling (d->listview)) {
+        if (!gtkui_listview_busy) {
             if (deadbeef->conf_get_int ("playlist.scroll.cursorfollowplayback", 1)) {
                 ddb_listview_select_single (d->listview, idx);
                 deadbeef->pl_set_cursor (PL_MAIN, idx);


### PR DESCRIPTION
I gave up trying to hack everything onto the DB_EV_FOCUS_SELECTION message.  Now this does what it used to, move the cursor and scroll to the first selected item in the current playlist in all listviews.  There is a new structured message for precisely setting the cursor to synchronise between the main and search listviews.  The first selected item is not always the one that should receive the cursor.

Playback following should now work in all cases, including in a background tab where playback stops, moves to a different tab, or the preferences are changed, and jump to track where there is no main playlist widget.  Playback following is done in gtkui.c for background tabs and if there is no listview widget to do it.  Otherwise all messages are acted on independently by the main and search listviews, the only synchronisation is for GUI actions on one or the other.

Playback following no longer occurs in the current playlist if it is being selected or dragged, basically the whole time between the left mouse button being pressed on a listview and released.