### PR TITLE
Text drawing changes

### DIFF
--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -120,7 +120,7 @@ ddb_listview_list_render_row_background (DdbListview *ps, cairo_t *cr, DdbListvi
 static void
 ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListviewIter it, int idx, int y, int w, int h, int x1, int x2);
 static void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int grp_next_y, int y, GdkRectangle *clip);
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int pinned, int grp_next_y, int y, GdkRectangle *clip);
 static void
 ddb_listview_list_track_dragdrop (DdbListview *ps, int x, int y);
 int
@@ -864,9 +864,6 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
     fill_list_background(listview, cr, scrollx, -listview->scrollpos, total_width, max(listview->fullheight, listview->list_height), clip);
 
     // find 1st group
-    for (DdbListviewGroup *grp_unpin = listview->groups; grp_unpin; grp_unpin = grp_unpin->next) {
-        grp_unpin->pinned = 0;
-    }
     DdbListviewGroup *grp = listview->groups;
     int idx = 0;
     int grp_y = -listview->scrollpos;
@@ -875,9 +872,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
         idx += grp->num_items;
         grp = grp->next;
     }
-    if (grp && grp_y < 0 && grp_y + grp->height >= 0) {
-        grp->pinned = 1;
-    }
+    DdbListviewGroup *pin_grp = gtkui_groups_pinned && grp && grp_y < 0 && grp_y + grp->height >= 0 ? grp : NULL;
 
     while (grp && grp_y < clip->y + clip->height) {
         int grp_height = title_height + grp->num_items * row_height;
@@ -900,9 +895,9 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
 
         // draw album art
         int grp_next_y = grp_y + grp->height;
-        ddb_listview_list_render_album_art(listview, cr, grp, grp_next_y, grp_y + title_height, clip);
+        ddb_listview_list_render_album_art(listview, cr, grp, pin_grp == grp, grp_next_y, grp_y + title_height, clip);
 
-        if (grp->pinned == 1 && gtkui_groups_pinned && clip->y <= title_height) {
+        if (pin_grp == grp && clip->y <= title_height) {
             // draw pinned group title
             fill_list_background(listview, cr, scrollx, 0, total_width, min(title_height, grp_next_y), clip);
 //            render_treeview_background(listview, cr, FALSE, TRUE, scrollx, 0, total_width, min(title_height, grp_next_y), clip);
@@ -1419,13 +1414,13 @@ ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListvi
 }
 
 static void
-ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int grp_next_y, int y, GdkRectangle *clip) {
+ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int pinned, int grp_next_y, int y, GdkRectangle *clip) {
     int x = -ps->hscrollpos;
     for (DdbListviewColumn *c = ps->columns; c && x < clip->x+clip->width; x += c->width, c = c->next) {
         if (ps->binding->is_album_art_column(c->user_data) && x + c->width > clip->x) {
             fill_list_background(ps, cr, x, y, c->width, grp->height-ps->grouptitle_height, clip);
             if (ps->grouptitle_height > 0) {
-                ps->binding->draw_album_art(ps, cr, grp->head, c->user_data, grp->pinned, grp_next_y, x, y, c->width, grp->height-ps->grouptitle_height);
+                ps->binding->draw_album_art(ps, cr, grp->head, c->user_data, pinned, grp_next_y, x, y, c->width, grp->height-ps->grouptitle_height);
             }
         }
     }

--- a/plugins/gtkui/drawing.h
+++ b/plugins/gtkui/drawing.h
@@ -90,7 +90,11 @@ void
 draw_text_with_colors (drawctx_t *ctx, float x, float y, int width, int align, const char *text);
 
 void
+draw_get_layout_extents (drawctx_t *ctx, int *w, int *h);
+
+void
 draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h);
+
 int
 draw_is_ellipsized (drawctx_t *ctx);
 

--- a/plugins/gtkui/gdkdrawing.c
+++ b/plugins/gtkui/gdkdrawing.c
@@ -229,16 +229,24 @@ draw_text_with_colors (drawctx_t *ctx, float x, float y, int width, int align, c
 }
 
 void
+draw_get_layout_extents (drawctx_t *ctx, int *w, int *h) {
+    PangoRectangle log;
+    pango_layout_get_pixel_extents (ctx->pangolayout, NULL, &log);
+    if (w) {
+        *w = log.width;
+    }
+    if (h) {
+        *h = log.height;
+    }
+}
+
+void
 draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h) {
     draw_init_font (ctx, 0, 0);
-    pango_layout_set_width (ctx->pangolayout, 1000 * PANGO_SCALE);
+    pango_layout_set_width (ctx->pangolayout, -1);
     pango_layout_set_alignment (ctx->pangolayout, PANGO_ALIGN_LEFT);
     pango_layout_set_text (ctx->pangolayout, text, len);
-    PangoRectangle ink;
-    PangoRectangle log;
-    pango_layout_get_pixel_extents (ctx->pangolayout, &ink, &log);
-    *w = ink.width;
-    *h = ink.height;
+    draw_get_layout_extents (ctx, w, h);
 }
 
 int

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1656,10 +1656,14 @@ pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
             float rgb[] = {clr.red/65535., clr.green/65535., clr.blue/65535.};
             draw_set_fg_color (&listview->grpctx, rgb);
         }
-        int ew, eh;
-        draw_get_text_extents (&listview->grpctx, str, -1, &ew, &eh);
-        draw_text_custom (&listview->grpctx, x + 5, y + height/2 - draw_get_listview_rowheight (&listview->grpctx)/2 + 3, ew+5, 0, DDB_GROUP_FONT, 0, 0, str);
-        draw_line (&listview->grpctx, x + 5 + ew + 3, y+height/2, x + width, y+height/2);
+        int ew;
+        draw_text_custom (&listview->grpctx, x + 5, y + height/2 - draw_get_listview_rowheight (&listview->grpctx)/2 + 3, -1, 0, DDB_GROUP_FONT, 0, 0, str);
+        draw_get_layout_extents (&listview->grpctx, &ew, NULL);
+        int len = strlen (str);
+        int line_x = x + 5 + ew + (len ? ew / len / 2 : 0);
+        if (line_x < x + width) {
+            draw_line (&listview->grpctx, line_x, y+height/2, x+width, y+height/2);
+        }
     }
 }
 

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -985,7 +985,12 @@ groups_changed (DdbListview *listview, const char *format)
         free(listview->group_title_bytecode);
         listview->group_title_bytecode = NULL;
     }
-    listview->binding->groups_changed(format);
+    char *esc_format = parser_escape_string (format);
+    char *quoted_format = malloc (strlen(esc_format) + 3);
+    sprintf (quoted_format, "\"%s\"", esc_format);
+    listview->binding->groups_changed(quoted_format);
+    free (quoted_format);
+    free (esc_format);
     listview->group_format = strdup(format);
     listview->group_title_bytecode = deadbeef->tf_compile(listview->group_format);
     ddb_listview_refresh(listview, DDB_LIST_CHANGED | DDB_REFRESH_LIST);
@@ -1691,7 +1696,8 @@ pl_common_col_sort (int sort_order, int iter, void *user_data) {
 void
 pl_common_set_group_format (DdbListview *listview, char *format_conf) {
     deadbeef->conf_lock ();
-    listview->group_format = strdup (deadbeef->conf_get_str_fast (format_conf, ""));
+    char *format = strdup (deadbeef->conf_get_str_fast (format_conf, ""));
     deadbeef->conf_unlock ();
+    listview->group_format = parser_unescape_quoted_string (format);
     listview->group_title_bytecode = deadbeef->tf_compile (listview->group_format);
 }

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -321,7 +321,7 @@ pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it,
     col_info_t *info = user_data;
 
     int art_x = x + ART_PADDING_HORZ;
-    int min_y = (pinned == 1 && gtkui_groups_pinned ? listview->grouptitle_height : y) + ART_PADDING_VERT;
+    int min_y = (pinned ? listview->grouptitle_height : y) + ART_PADDING_VERT;
     if (info->cover_size == art_width) {
         cover_draw_exact(it, art_x, min_y, next_y, art_width, art_height, cr, user_data);
     }

--- a/plugins/libparser/parser.c
+++ b/plugins/libparser/parser.c
@@ -153,3 +153,19 @@ parser_escape_string (const char *in) {
     return output;
 }
 
+char *
+parser_unescape_quoted_string (char *in) {
+    char *out = in;
+    char *next = in;
+    if (next[0] == '"') {
+        next++;
+    }
+    while (*next && *next != '"') {
+        if (*next == '\\' && (*(next+1) == '"' || *(next+1) == '\\')) {
+            next++;
+        }
+        *out++ = *next++;
+    }
+    *out = '\0';
+    return in;
+}

--- a/plugins/libparser/parser.h
+++ b/plugins/libparser/parser.h
@@ -52,4 +52,7 @@ gettoken_err_eof (const char *p, char *tok);
 char *
 parser_escape_string (const char *in);
 
+char *
+parser_unescape_quoted_string (char *in);
+
 #endif


### PR DESCRIPTION
This is to fix issue #1381.  The extent of text was incorrectly calculated, especially with leading or trailing whitespace.

It also preserves leading and trailing whitespace in group formats  At the moment, it is saved for a while, then lost on restart.