### PR TITLE
Fix useless warnings for non-existing menus.

### DIFF
--- a/plugins/gtkui/actions.c
+++ b/plugins/gtkui/actions.c
@@ -165,7 +165,7 @@ add_mainmenu_actions (void)
                 snprintf (menuname, sizeof (menuname), "%s_menu", ptr);
 
                 previous = current;
-                current = lookup_widget (mainwin, menuname);
+                current = (GtkWidget*) g_object_get_data (G_OBJECT (mainwin), menuname);
                 if (!current)
                 {
                     GtkWidget *newitem;


### PR DESCRIPTION
No need to use the generic lookup_widget() function. We know what we are dealing with
so can do the right thing.