### PR TITLE
Make %album artist% more consistent with foobar2000 and remove some gtk warnings

### DIFF
--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1054,6 +1054,7 @@ on_group_by_custom_activate            (GtkMenuItem     *menuitem,
 
     DdbListview *listview = get_context_menu_listview (menuitem);
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
+    gtk_window_set_transient_for (GTK_WINDOW (dlg), GTK_WINDOW (mainwin));
     GtkWidget *entry = lookup_widget (dlg, "format");
     if (listview->group_format) {
         gtk_entry_set_text (GTK_ENTRY (entry), listview->group_format);
@@ -1341,6 +1342,7 @@ on_add_column_activate                 (GtkMenuItem     *menuitem,
     GtkWidget *dlg = create_editcolumndlg ();
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
     gtk_window_set_title (GTK_WINDOW (dlg), _("Add column"));
+    gtk_window_set_transient_for (GTK_WINDOW (dlg), GTK_WINDOW (mainwin));
     gtk_combo_box_set_active (GTK_COMBO_BOX (lookup_widget (dlg, "id")), 0);
     gtk_combo_box_set_active (GTK_COMBO_BOX (lookup_widget (dlg, "align")), 0);
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (dlg, "color_override")), 0);
@@ -1380,6 +1382,7 @@ on_edit_column_activate                (GtkMenuItem     *menuitem,
     GtkWidget *dlg = create_editcolumndlg ();
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
     gtk_window_set_title (GTK_WINDOW (dlg), _("Edit column"));
+    gtk_window_set_transient_for (GTK_WINDOW (dlg), GTK_WINDOW (mainwin));
 
     const char *title;
     int width;

--- a/tf.c
+++ b/tf.c
@@ -1296,7 +1296,7 @@ tf_eval_int (ddb_tf_context_t *ctx, char *code, int size, char *out, int outlen,
                 // compatible with fb2k syntax
                 pl_lock ();
                 const char *val = NULL;
-                const char *aa_fields[] = { "album artist", "albumartist", "band", "composer", "performer", "artist", NULL };
+                const char *aa_fields[] = { "album artist", "albumartist", "band", "artist", "composer", "performer", NULL };
                 const char *a_fields[] = { "artist", "album artist", "albumartist", "composer", "performer", NULL };
                 const char *alb_fields[] = { "album", "venue", NULL };
 


### PR DESCRIPTION
%album artist% in foobar2000 works like that:

>%album artist%: Name of the artist of the album specified track belongs to. Checks following metadata fields, in this order: "album artist", "artist", "composer", "performer".