### PR TITLE
osx: Removing define for '/usr/local/bin/' encoder path in OSX.

### DIFF
--- a/plugins/cocoaui/deadbeef-Info.plist
+++ b/plugins/cocoaui/deadbeef-Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin</string>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -928,11 +928,6 @@ convert (DB_playItem_t *it, const char *out, int output_bps, int output_is_float
             char *o = enc;
             *o = 0;
 
-#ifdef __APPLE__
-            strcpy (o, "/usr/local/bin/");
-            o += 15;
-#endif
-
             int len = sizeof (enc);
             while (e && *e) {
                 if (len <= 0) {


### PR DESCRIPTION
This removes the define for '/usr/local/bin/' encoder path in OSX. 
Execution of encoders now relies only in the PATH env variable when no full path is given (like in Linux). Set PATH variable value in LSEnvironment,deadbeef-Info.plist to '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin' (if no value is set, the default is '/usr/bin:/bin:/usr/sbin:/sbin'). This is only applicable when launched through Launch Services. If executed directly from the command line the env variables of the shell are used and the LSEnvironmnt dictionary is ignored.
This last part is also applicable to Xcode. When running in Xcode the path variable must be set in the schema preferences.

https://developer.apple.com/library/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-106825