### PR TITLE
gtkui: add new splitter widget

### DIFF
--- a/plugins/gtkui/Makefile.am
+++ b/plugins/gtkui/Makefile.am
@@ -35,6 +35,8 @@ GTKUI_SOURCES =    gtkui.c gtkui.h\
                    ctmapping.c ctmapping.h\
                    namedicons.c namedicons.h\
                    tfimport.c tfimport.h\
+                   ddb_splitter.c ddb_splitter.h\
+                   ddb_splitter_size_mode.c ddb_splitter_size_mode.h\
 				   $(SM_SOURCES) $(OSXSRC)
 
 sdkdir = $(pkgincludedir)

--- a/plugins/gtkui/ddb_splitter.c
+++ b/plugins/gtkui/ddb_splitter.c
@@ -396,7 +396,7 @@ static gboolean
 ddb_splitter_children_visible (DdbSplitter *splitter)
 {
     g_return_val_if_fail (DDB_IS_SPLITTER (splitter), FALSE);
-    if (splitter->priv->child1 
+    if (splitter->priv->child1
             && gtk_widget_get_visible (GTK_WIDGET (splitter->priv->child1))
             && splitter->priv->child2
             && gtk_widget_get_visible (GTK_WIDGET (splitter->priv->child2))) {
@@ -410,13 +410,13 @@ ddb_splitter_is_child_visible (DdbSplitter *splitter, guint child)
 {
     g_return_val_if_fail (DDB_IS_SPLITTER (splitter), FALSE);
     if (child == 0) {
-        if (splitter->priv->child1 
+        if (splitter->priv->child1
                 && gtk_widget_get_visible (GTK_WIDGET (splitter->priv->child1))) {
             return TRUE;
         }
     }
     else if (child == 1) {
-        if (splitter->priv->child2 
+        if (splitter->priv->child2
                 && gtk_widget_get_visible (GTK_WIDGET (splitter->priv->child2))) {
             return TRUE;
         }

--- a/plugins/gtkui/ddb_splitter.c
+++ b/plugins/gtkui/ddb_splitter.c
@@ -276,8 +276,7 @@ ddb_splitter_get_property (GObject *object,
 {
     DdbSplitter *splitter = DDB_SPLITTER (object);
 
-    switch (prop_id)
-    {
+    switch (prop_id) {
         case PROP_ORIENTATION:
             g_value_set_enum (value, ddb_splitter_get_orientation (splitter));
             break;
@@ -304,8 +303,7 @@ ddb_splitter_set_property (GObject *object,
 {
     DdbSplitter *splitter = DDB_SPLITTER (object);
 
-    switch (prop_id)
-    {
+    switch (prop_id) {
         case PROP_ORIENTATION:
             ddb_splitter_set_orientation (splitter, g_value_get_enum (value));
             break;
@@ -463,8 +461,7 @@ ddb_splitter_button_release (GtkWidget      *widget,
 {
     DdbSplitter *splitter = DDB_SPLITTER (widget);
 
-    if (splitter->priv->in_drag && (event->button == 1))
-    {
+    if (splitter->priv->in_drag && (event->button == 1)) {
         stop_drag (splitter);
 
         return TRUE;
@@ -507,8 +504,7 @@ ddb_splitter_motion (GtkWidget      *widget,
 {
     DdbSplitter *splitter = DDB_SPLITTER (widget);
 
-    if (splitter->priv->in_drag)
-    {
+    if (splitter->priv->in_drag) {
         update_drag (splitter);
         return TRUE;
     }
@@ -616,8 +612,7 @@ ddb_splitter_realize (GtkWidget *widget)
                 GDK_POINTER_MOTION_MASK |
                 GDK_POINTER_MOTION_HINT_MASK);
         attributes_mask = GDK_WA_X | GDK_WA_Y;
-        if (gtk_widget_is_sensitive (widget))
-        {
+        if (gtk_widget_is_sensitive (widget)) {
             if (splitter->priv->size_mode != DDB_SPLITTER_SIZE_MODE_PROP) {
                 attributes.cursor = NULL;
             }
@@ -656,8 +651,7 @@ ddb_splitter_unrealize (GtkWidget *widget)
 {
     DdbSplitter *splitter = DDB_SPLITTER (widget);
 
-    if (splitter->priv->handle)
-    {
+    if (splitter->priv->handle) {
         gdk_window_set_user_data (splitter->priv->handle, NULL);
         gdk_window_destroy (splitter->priv->handle);
         splitter->priv->handle = NULL;
@@ -723,8 +717,7 @@ ddb_splitter_size_request (GtkWidget      *widget,
         requisition->height += req_c1.height + req_c2.height;
     }
 
-    if (ddb_splitter_children_visible (splitter))
-    {
+    if (ddb_splitter_children_visible (splitter)) {
         if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
             requisition->width += DDB_SPLITTER_PANE_SIZE;
         else
@@ -1023,8 +1016,7 @@ ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
         if (gtk_widget_get_mapped (widget))
             gdk_window_show (splitter->priv->handle);
 
-        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
-        {
+        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL) {
             gdk_window_move_resize (splitter->priv->handle,
                     splitter->priv->handle_pos.x,
                     splitter->priv->handle_pos.y,
@@ -1071,8 +1063,7 @@ ddb_splitter_add (GtkContainer *container, GtkWidget *widget)
         gtk_widget_realize (widget);
 
     /* map the widget if required */
-    if (gtk_widget_get_visible (GTK_WIDGET (container)) && gtk_widget_get_visible (widget))
-    {
+    if (gtk_widget_get_visible (GTK_WIDGET (container)) && gtk_widget_get_visible (widget)) {
         if (gtk_widget_get_mapped (GTK_WIDGET (container)))
             gtk_widget_map (widget);
     }
@@ -1162,8 +1153,7 @@ ddb_splitter_add_child_at_pos (DdbSplitter *splitter, GtkWidget *child, guint po
         gtk_widget_realize (child);
 
     /* map the widget if required */
-    if (gtk_widget_get_visible (GTK_WIDGET (splitter)) && gtk_widget_get_visible (child))
-    {
+    if (gtk_widget_get_visible (GTK_WIDGET (splitter)) && gtk_widget_get_visible (child)) {
         if (gtk_widget_get_mapped (GTK_WIDGET (splitter)))
             gtk_widget_map (child);
     }
@@ -1199,8 +1189,7 @@ ddb_splitter_set_size_mode (DdbSplitter *splitter, DdbSplitterSizeMode size_mode
 {
     g_return_if_fail (DDB_IS_SPLITTER (splitter));
 
-    if (G_LIKELY (splitter->priv->size_mode != size_mode))
-    {
+    if (G_LIKELY (splitter->priv->size_mode != size_mode)) {
         splitter->priv->size_mode = size_mode;
         ddb_splitter_update_cursor (splitter);
         gtk_widget_queue_resize (GTK_WIDGET (splitter));
@@ -1235,8 +1224,7 @@ ddb_splitter_set_orientation (DdbSplitter *splitter, GtkOrientation orientation)
 {
     g_return_if_fail (DDB_IS_SPLITTER (splitter));
 
-    if (G_LIKELY (splitter->priv->orientation != orientation))
-    {
+    if (G_LIKELY (splitter->priv->orientation != orientation)) {
         splitter->priv->orientation = orientation;
         gtk_widget_queue_resize (GTK_WIDGET (splitter));
         g_object_notify (G_OBJECT (splitter), "orientation");
@@ -1311,7 +1299,7 @@ ddb_splitter_set_child2_size (DdbSplitter *splitter, guint size)
 
 /* Return a new PSquare cast to a GtkWidget */
 GtkWidget *
-ddb_splitter_new(GtkOrientation orientation)
+ddb_splitter_new (GtkOrientation orientation)
 {
     return GTK_WIDGET (g_object_new (ddb_splitter_get_type (), "orientation", orientation, NULL));
 }

--- a/plugins/gtkui/ddb_splitter.c
+++ b/plugins/gtkui/ddb_splitter.c
@@ -1,0 +1,1281 @@
+/*
+ * Copyright (c) 2016 Christian Boxdörfer <christian.boxdoerfer@posteo.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#include <math.h>
+#include "ddb_splitter.h"
+
+/**
+ * SECTION: ddb-splitter
+ * @title: DdbSplitter
+ * @short_description: A container widget similar to GtkPaned, but with
+ * the ability to use proportional resizing
+ **/
+
+#define DDB_SPLITTER_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), \
+            DDB_TYPE_SPLITTER, DdbSplitterPrivate))
+
+/* Property identifiers */
+enum
+{
+    PROP_0,
+    PROP_ORIENTATION,
+    PROP_SIZE_MODE,
+    PROP_PROPORTION,
+};
+
+#define DDB_SPLITTER_PANE_SIZE 6
+
+#if !GTK_CHECK_VERSION(3,0,0)
+static void
+ddb_splitter_size_request (GtkWidget        *widget,
+                           GtkRequisition   *requisition);
+#else
+static void
+ddb_splitter_get_preferred_width (GtkWidget *widget,
+                               gint *minimum,
+                               gint *natural);
+
+static void
+ddb_splitter_get_preferred_height (GtkWidget *widget,
+                               gint *minimum,
+                               gint *natural);
+
+static void
+ddb_splitter_get_preferred_width_for_height (GtkWidget *widget,
+                               gint height,
+                               gint *minimum,
+                               gint *natural);
+
+static void
+ddb_splitter_get_preferred_height_for_width (GtkWidget *widget,
+                               gint width,
+                               gint *minimum,
+                               gint *natural);
+#endif
+
+static gboolean
+ddb_splitter_button_press (GtkWidget *widget,
+                        GdkEventButton *event);
+static gboolean
+ddb_splitter_button_release (GtkWidget *widget,
+                             GdkEventButton *event);
+static gboolean
+ddb_splitter_grab_broken (GtkWidget *widget,
+                GdkEventGrabBroken *event);
+static void
+ddb_splitter_grab_notify (GtkWidget *widget,
+                       gboolean   was_grabbed);
+static gboolean
+ddb_splitter_motion (GtkWidget *widget,
+                     GdkEventMotion *event);
+#if GTK_CHECK_VERSION(3,0,0)
+static gboolean
+ddb_splitter_draw (GtkWidget *widget,
+                cairo_t   *cr);
+#else
+static gboolean
+ddb_splitter_expose (GtkWidget      *widget,
+                  GdkEventExpose *event);
+#endif
+static void
+ddb_splitter_realize (GtkWidget *widget);
+
+static void
+ddb_splitter_unrealize (GtkWidget *widget);
+
+static void
+ddb_splitter_map (GtkWidget *widget);
+
+static void
+ddb_splitter_unmap (GtkWidget *widget);
+
+static void
+ddb_splitter_get_property (GObject *object,
+                           guint prop_id,
+                           GValue *value,
+                           GParamSpec *pspec);
+static void
+ddb_splitter_set_property (GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec);
+
+static void
+ddb_splitter_set_orientation (DdbSplitter *splitter,
+                              GtkOrientation orientation);
+
+static void
+ddb_splitter_size_allocate (GtkWidget *widget,
+                            GtkAllocation *allocation);
+static void
+ddb_splitter_add (GtkContainer *container,
+                  GtkWidget *widget);
+static void
+ddb_splitter_remove (GtkContainer *container,
+                     GtkWidget *widget);
+static void
+ddb_splitter_forall (GtkContainer *container,
+                     gboolean include_internals,
+                     GtkCallback callback,
+                     gpointer callback_data);
+
+struct _DdbSplitterPrivate
+{
+    GtkWidget *child1;
+    GtkWidget *child2;
+    GdkWindow *handle;
+    GdkRectangle handle_pos;
+    gint handle_size;
+    gint drag_pos;
+    guint in_drag : 1;
+    guint position_set : 1;
+    guint32 grab_time;
+
+    /* configurable parameters */
+    guint child1_size;
+    guint child2_size;
+
+    GtkOrientation orientation;
+    DdbSplitterSizeMode size_mode;
+    gfloat proportion;
+};
+
+G_DEFINE_TYPE (DdbSplitter, ddb_splitter, GTK_TYPE_CONTAINER)
+
+static void
+ddb_splitter_class_init (DdbSplitterClass *klass)
+{
+    GtkContainerClass *gtkcontainer_class;
+    GtkWidgetClass    *gtkwidget_class;
+    GObjectClass      *gobject_class;
+
+    /* add our private data to the class */
+    g_type_class_add_private (klass, sizeof (DdbSplitterPrivate));
+
+    gobject_class = G_OBJECT_CLASS (klass);
+    gobject_class->get_property = ddb_splitter_get_property;
+    gobject_class->set_property = ddb_splitter_set_property;
+
+    gtkwidget_class = GTK_WIDGET_CLASS (klass);
+#if !GTK_CHECK_VERSION(3,0,0)
+    gtkwidget_class->size_request = ddb_splitter_size_request;
+#else
+    gtkwidget_class->get_preferred_width = ddb_splitter_get_preferred_width;
+    gtkwidget_class->get_preferred_height = ddb_splitter_get_preferred_height;
+    gtkwidget_class->get_preferred_width_for_height = ddb_splitter_get_preferred_width_for_height;
+    gtkwidget_class->get_preferred_height_for_width = ddb_splitter_get_preferred_height_for_width;
+#endif
+    gtkwidget_class->size_allocate = ddb_splitter_size_allocate;
+    gtkwidget_class->realize = ddb_splitter_realize;
+#if GTK_CHECK_VERSION(3,0,0)
+    gtkwidget_class->draw = ddb_splitter_draw;
+#else
+    gtkwidget_class->expose_event = ddb_splitter_expose;
+#endif
+    gtkwidget_class->unrealize = ddb_splitter_unrealize;
+    gtkwidget_class->map = ddb_splitter_map;
+    gtkwidget_class->unmap = ddb_splitter_unmap;
+    gtkwidget_class->button_press_event = ddb_splitter_button_press;
+    gtkwidget_class->button_release_event = ddb_splitter_button_release;
+    gtkwidget_class->motion_notify_event = ddb_splitter_motion;
+    gtkwidget_class->grab_broken_event = ddb_splitter_grab_broken;
+    gtkwidget_class->grab_notify = ddb_splitter_grab_notify;
+
+    gtkcontainer_class = GTK_CONTAINER_CLASS (klass);
+    gtkcontainer_class->add = ddb_splitter_add;
+    gtkcontainer_class->remove = ddb_splitter_remove;
+    gtkcontainer_class->forall = ddb_splitter_forall;
+
+    /**
+     * DdbSplitter::size_mode:
+     *
+     * The size mode of the splitter.
+     **/
+    g_object_class_install_property (gobject_class,
+            PROP_SIZE_MODE,
+            g_param_spec_enum ("size-mode",
+                "Size mode",
+                "The size mode of the splitter widget",
+                DDB_SPLITTER_TYPE_SIZE_MODE, DDB_SPLITTER_SIZE_MODE_PROP,
+                G_PARAM_READWRITE));
+    /**
+     * DdbSplitter::orientation:
+     *
+     * The orientation of the splitter.
+     **/
+    g_object_class_install_property (gobject_class,
+            PROP_ORIENTATION,
+            g_param_spec_enum ("orientation",
+                "Orientation",
+                "The orientation of the splitter widget",
+                GTK_TYPE_ORIENTATION, GTK_ORIENTATION_HORIZONTAL,
+                G_PARAM_READWRITE));
+    /**
+     * DdbSplitter::proportion:
+     *
+     * The percentage of space allocated to the first child.
+     **/
+    g_object_class_install_property (gobject_class,
+            PROP_PROPORTION,
+            g_param_spec_float ("proportion",
+                "Proportion",
+                "The percentage of space allocated to the first child",
+                -G_MAXFLOAT, 1.0, -1.0,
+                G_PARAM_READWRITE));
+}
+
+static void
+ddb_splitter_init (DdbSplitter *splitter)
+{
+    /* grab a pointer on the private data */
+    splitter->priv = DDB_SPLITTER_GET_PRIVATE (splitter);
+
+    splitter->priv->orientation = GTK_ORIENTATION_HORIZONTAL;
+    splitter->priv->size_mode = DDB_SPLITTER_SIZE_MODE_PROP;
+    splitter->priv->drag_pos = -1;
+    splitter->priv->in_drag = FALSE;
+    splitter->priv->position_set = FALSE;
+    splitter->priv->child1 = NULL;
+    splitter->priv->child2 = NULL;
+    splitter->priv->child1_size = 0;
+    splitter->priv->child2_size = 0;
+    splitter->priv->handle = NULL;
+    splitter->priv->handle_size = DDB_SPLITTER_PANE_SIZE;
+    splitter->priv->handle_pos.x = -1;
+    splitter->priv->handle_pos.y = -1;
+    splitter->priv->handle_pos.width = DDB_SPLITTER_PANE_SIZE;
+    splitter->priv->handle_pos.height = DDB_SPLITTER_PANE_SIZE;
+    splitter->priv->proportion = 0.5f;
+    /* we don't provide our own window */
+    gtk_widget_set_can_focus (GTK_WIDGET (splitter), FALSE);
+    gtk_widget_set_has_window (GTK_WIDGET (splitter), FALSE);
+    gtk_widget_set_redraw_on_allocate (GTK_WIDGET (splitter), FALSE);
+}
+
+static void
+ddb_splitter_get_property (GObject *object,
+                           guint prop_id,
+                           GValue *value,
+                           GParamSpec *pspec)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (object);
+
+    switch (prop_id)
+    {
+        case PROP_ORIENTATION:
+            g_value_set_enum (value, ddb_splitter_get_orientation (splitter));
+            break;
+
+        case PROP_SIZE_MODE:
+            g_value_set_enum (value, ddb_splitter_get_size_mode (splitter));
+            break;
+
+        case PROP_PROPORTION:
+            g_value_set_float (value, ddb_splitter_get_proportion (splitter));
+            break;
+
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static void
+ddb_splitter_set_property (GObject *object,
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (object);
+
+    switch (prop_id)
+    {
+        case PROP_ORIENTATION:
+            ddb_splitter_set_orientation (splitter, g_value_get_enum (value));
+            break;
+
+        case PROP_SIZE_MODE:
+            ddb_splitter_set_size_mode (splitter, g_value_get_enum (value));
+            break;
+
+        case PROP_PROPORTION:
+            ddb_splitter_set_proportion (splitter, g_value_get_float (value));
+            break;
+
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            break;
+    }
+}
+
+static gboolean
+ddb_splitter_button_press (GtkWidget      *widget,
+                        GdkEventButton *event)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (event->window == splitter->priv->handle
+           && event->button == 1
+           && event->type == GDK_2BUTTON_PRESS) {
+        ddb_splitter_set_proportion (splitter, 0.5f);
+        return TRUE;
+    }
+    if (!splitter->priv->in_drag &&
+            (event->window == splitter->priv->handle) && (event->button == 1))
+    {
+        /* We need a server grab here, not gtk_grab_add(), since
+         * we don't want to pass events on to the widget's children */
+        if (gdk_pointer_grab (splitter->priv->handle, FALSE,
+                    GDK_POINTER_MOTION_HINT_MASK
+                    | GDK_BUTTON1_MOTION_MASK
+                    | GDK_BUTTON_RELEASE_MASK
+                    | GDK_ENTER_NOTIFY_MASK
+                    | GDK_LEAVE_NOTIFY_MASK,
+                    NULL, NULL,
+                    event->time) != GDK_GRAB_SUCCESS)
+            return FALSE;
+
+        splitter->priv->in_drag = TRUE;
+        splitter->priv->grab_time = event->time;
+
+        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
+            splitter->priv->drag_pos = event->x;
+        else
+            splitter->priv->drag_pos = event->y;
+
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static void
+ddb_splitter_update_cursor (DdbSplitter *splitter)
+{
+    if (gtk_widget_get_realized (GTK_WIDGET (splitter))) {
+        GdkCursor *cursor = NULL;
+        if (splitter->priv->size_mode != DDB_SPLITTER_SIZE_MODE_PROP) {
+            cursor = NULL;
+        }
+        else {
+            if (splitter->priv->orientation == GTK_ORIENTATION_VERTICAL) {
+                cursor = gdk_cursor_new_for_display (gtk_widget_get_display (GTK_WIDGET (splitter)),
+                        GDK_SB_V_DOUBLE_ARROW);
+            }
+            else {
+                cursor = gdk_cursor_new_for_display (gtk_widget_get_display (GTK_WIDGET (splitter)),
+                        GDK_SB_H_DOUBLE_ARROW);
+            }
+        }
+
+        gdk_window_set_cursor (splitter->priv->handle, cursor);
+
+        if (cursor) {
+            gdk_cursor_unref (cursor);
+        }
+    }
+}
+
+static gboolean
+ddb_splitter_grab_broken (GtkWidget          *widget,
+                       GdkEventGrabBroken *event)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    splitter->priv->in_drag = FALSE;
+    splitter->priv->drag_pos = -1;
+    splitter->priv->position_set = TRUE;
+
+    return TRUE;
+}
+
+static void
+stop_drag (DdbSplitter *splitter)
+{
+    splitter->priv->in_drag = FALSE;
+    splitter->priv->drag_pos = -1;
+    splitter->priv->position_set = TRUE;
+    gdk_display_pointer_ungrab (gtk_widget_get_display (GTK_WIDGET (splitter)),
+            splitter->priv->grab_time);
+}
+
+static void
+ddb_splitter_grab_notify (GtkWidget *widget,
+                       gboolean   was_grabbed)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (!was_grabbed && splitter->priv->in_drag)
+        stop_drag (splitter);
+}
+
+static gboolean
+ddb_splitter_button_release (GtkWidget      *widget,
+                          GdkEventButton *event)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (splitter->priv->in_drag && (event->button == 1))
+    {
+        stop_drag (splitter);
+
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static void
+update_drag (DdbSplitter *splitter)
+{
+    gint pos;
+    gint handle_size;
+    gint size;
+
+    if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
+        gtk_widget_get_pointer (GTK_WIDGET (splitter), &pos, NULL);
+    else
+        gtk_widget_get_pointer (GTK_WIDGET (splitter), NULL, &pos);
+
+    pos -= splitter->priv->drag_pos;
+
+    size = pos;
+
+    GtkAllocation a;
+    gtk_widget_get_allocation (GTK_WIDGET (splitter), &a);
+    if (size != splitter->priv->child1_size) {
+        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL) {
+            ddb_splitter_set_proportion (splitter, CLAMP ((float)size/a.width, 0.0f, 1.0f));
+        }
+        else {
+            ddb_splitter_set_proportion (splitter, CLAMP ((float)size/a.height, 0.0f, 1.0f));
+        }
+    }
+}
+
+static gboolean
+ddb_splitter_motion (GtkWidget      *widget,
+                  GdkEventMotion *event)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (splitter->priv->in_drag)
+    {
+        update_drag (splitter);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+#if GTK_CHECK_VERSION(3,0,0)
+static gboolean
+ddb_splitter_draw (GtkWidget *widget,
+                cairo_t   *cr)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (gtk_widget_get_visible (widget) && gtk_widget_get_mapped (widget) &&
+            splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1) &&
+            splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2))
+    {
+        if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_PROP) {
+            gtk_render_handle (gtk_widget_get_style_context (widget), cr,
+                    splitter->priv->handle_pos.x, splitter->priv->handle_pos.y,
+                    splitter->priv->handle_pos.width, splitter->priv->handle_pos.height);
+        }
+        else {
+            gtk_render_background (gtk_widget_get_style_context (widget), cr,
+                    splitter->priv->handle_pos.x, splitter->priv->handle_pos.y,
+                    splitter->priv->handle_pos.width, splitter->priv->handle_pos.height);
+        }
+    }
+
+    /* Chain up to draw children */
+    GTK_WIDGET_CLASS (ddb_splitter_parent_class)->draw (widget, cr);
+
+    return FALSE;
+}
+
+#else
+
+static gboolean
+ddb_splitter_expose (GtkWidget      *widget,
+                  GdkEventExpose *event)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (gtk_widget_get_visible (widget) && gtk_widget_get_mapped (widget) &&
+            splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1) &&
+            splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2))
+    {
+        GtkStateType state;
+
+        if (gtk_widget_is_focus (widget))
+            state = GTK_STATE_SELECTED;
+        else
+            state = gtk_widget_get_state (widget);
+
+        //cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+        if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_PROP) {
+            gtk_paint_handle (gtk_widget_get_style (widget), gtk_widget_get_window (widget),
+                    state, GTK_SHADOW_NONE,
+                    &splitter->priv->handle_pos, widget, "paned",
+                    splitter->priv->handle_pos.x, splitter->priv->handle_pos.y,
+                    splitter->priv->handle_pos.width, splitter->priv->handle_pos.height,
+                    !splitter->priv->orientation);
+        }
+        else {
+            gtk_paint_box (gtk_widget_get_style (widget), gtk_widget_get_window (widget),
+                    state, GTK_SHADOW_NONE,
+                    &splitter->priv->handle_pos, widget, "paned",
+                    splitter->priv->handle_pos.x, splitter->priv->handle_pos.y,
+                    splitter->priv->handle_pos.width, splitter->priv->handle_pos.height);
+        }
+        //cairo_destroy (cr);
+    }
+
+    /* Chain up to draw children */
+    GTK_WIDGET_CLASS (ddb_splitter_parent_class)->expose_event (widget, event);
+
+    return FALSE;
+}
+#endif
+
+static void
+ddb_splitter_realize (GtkWidget *widget)
+{
+    GdkWindowAttr attributes;
+    gint attributes_mask;
+
+    gtk_widget_set_realized (widget, TRUE);
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    GdkWindow *parent = gtk_widget_get_parent_window (widget);
+    gtk_widget_set_window (widget, parent);
+    if (parent) {
+        g_object_ref (parent);
+
+        attributes.window_type = GDK_WINDOW_CHILD;
+        attributes.wclass = GDK_INPUT_ONLY;
+        attributes.x = splitter->priv->handle_pos.x;
+        attributes.y = splitter->priv->handle_pos.y;
+        attributes.width = splitter->priv->handle_pos.width;
+        attributes.height = splitter->priv->handle_pos.height;
+        attributes.event_mask = gtk_widget_get_events (widget);
+        attributes.event_mask |= (GDK_BUTTON_PRESS_MASK |
+                GDK_BUTTON_RELEASE_MASK |
+                GDK_ENTER_NOTIFY_MASK |
+                GDK_LEAVE_NOTIFY_MASK |
+                GDK_POINTER_MOTION_MASK |
+                GDK_POINTER_MOTION_HINT_MASK);
+        attributes_mask = GDK_WA_X | GDK_WA_Y;
+        if (gtk_widget_is_sensitive (widget))
+        {
+            if (splitter->priv->size_mode != DDB_SPLITTER_SIZE_MODE_PROP) {
+                attributes.cursor = NULL;
+            }
+            else {
+                if (splitter->priv->orientation == GTK_ORIENTATION_VERTICAL) {
+                    attributes.cursor = gdk_cursor_new_for_display (gtk_widget_get_display (widget),
+                            GDK_SB_V_DOUBLE_ARROW);
+                }
+                else {
+                    attributes.cursor = gdk_cursor_new_for_display (gtk_widget_get_display (widget),
+                            GDK_SB_H_DOUBLE_ARROW);
+                }
+            }
+            attributes_mask |= GDK_WA_CURSOR;
+        }
+
+        splitter->priv->handle = gdk_window_new (parent,
+                &attributes, attributes_mask);
+        gdk_window_set_user_data (splitter->priv->handle, splitter);
+        if (attributes_mask & GDK_WA_CURSOR && attributes.cursor)
+            gdk_cursor_unref (attributes.cursor);
+
+        gtk_widget_style_attach (widget);
+        //gtk_style_attach (widget, parent);
+        //widget->style = gtk_style_attach (widget->style, widget->window);
+
+        if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1) &&
+                splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2))
+            gdk_window_show (splitter->priv->handle);
+    }
+}
+
+static void
+ddb_splitter_unrealize (GtkWidget *widget)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    if (splitter->priv->handle)
+    {
+        gdk_window_set_user_data (splitter->priv->handle, NULL);
+        gdk_window_destroy (splitter->priv->handle);
+        splitter->priv->handle = NULL;
+    }
+
+    GTK_WIDGET_CLASS (ddb_splitter_parent_class)->unrealize (widget);
+}
+
+static void
+ddb_splitter_map (GtkWidget *widget)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    gdk_window_show (splitter->priv->handle);
+
+    GTK_WIDGET_CLASS (ddb_splitter_parent_class)->map (widget);
+}
+
+static void
+ddb_splitter_unmap (GtkWidget *widget)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    gdk_window_hide (splitter->priv->handle);
+
+    GTK_WIDGET_CLASS (ddb_splitter_parent_class)->unmap (widget);
+}
+
+#if !GTK_CHECK_VERSION(3,0,0)
+static void
+ddb_splitter_size_request (GtkWidget      *widget,
+        GtkRequisition *requisition)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+
+    gint border_width = 0;
+    GtkRequisition req_c1;
+    req_c1.width = 0;
+    req_c1.height = 0;
+    if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1)) {
+        gtk_widget_size_request (splitter->priv->child1, &req_c1);
+    }
+
+    GtkRequisition req_c2;
+    req_c2.width = 0;
+    req_c2.height = 0;
+    if (splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2)) {
+        gtk_widget_size_request (splitter->priv->child2, &req_c2);
+    }
+
+    requisition->width = 0;
+    requisition->height = 0;
+    requisition->width += border_width * 2;
+    requisition->height += border_width * 2;
+
+    if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL) {
+        requisition->width += req_c1.width + req_c2.width;
+        requisition->height += MAX (req_c1.height, req_c2.height);
+    }
+    else {
+        requisition->width += MAX (req_c1.width, req_c2.width);
+        requisition->height += req_c1.height + req_c2.height;
+    }
+
+    if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1) &&
+            splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2))
+    {
+        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
+            requisition->width += DDB_SPLITTER_PANE_SIZE;
+        else
+            requisition->height += DDB_SPLITTER_PANE_SIZE;
+    }
+}
+#else
+static void
+ddb_splitter_get_preferred_width (GtkWidget *widget,
+                               gint *minimum,
+                               gint *natural)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+    gint min = 0;
+    gint nat = 0;
+    gint child1_min = 0;
+    gint child1_nat = 0;
+    gint child2_min = 0;
+    gint child2_nat = 0;
+
+    if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1)) {
+        gtk_widget_get_preferred_width (splitter->priv->child1, &child1_min, &child2_nat);
+    }
+    if (splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2)) {
+        gtk_widget_get_preferred_width (splitter->priv->child2, &child2_min, &child2_nat);
+    }
+
+    if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL) {
+        nat = child1_nat + child2_nat;
+        if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1)
+                && splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2)) {
+            min += splitter->priv->handle_size;
+            nat += splitter->priv->handle_size;
+        }
+    }
+    else {
+        nat = MAX (child1_nat, child2_nat);
+    }
+    *minimum = min;
+    *natural = nat;
+}
+
+static void
+ddb_splitter_get_preferred_height (GtkWidget *widget,
+                               gint *minimum,
+                               gint *natural)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+    gint min = 0;
+    gint nat = 0;
+    gint child1_min = 0;
+    gint child1_nat = 0;
+    gint child2_min = 0;
+    gint child2_nat = 0;
+
+    if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1)) {
+        gtk_widget_get_preferred_height (splitter->priv->child1, &child1_min, &child2_nat);
+    }
+    if (splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2)) {
+        gtk_widget_get_preferred_height (splitter->priv->child2, &child2_min, &child2_nat);
+    }
+
+    if (splitter->priv->orientation == GTK_ORIENTATION_VERTICAL) {
+        nat = child1_nat + child2_nat;
+        if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1)
+                && splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2)) {
+            min += splitter->priv->handle_size;
+            nat += splitter->priv->handle_size;
+        }
+    }
+    else {
+        nat = MAX (child1_nat, child2_nat);
+    }
+    *minimum = min;
+    *natural = nat;
+}
+
+static void
+ddb_splitter_get_preferred_width_for_height (GtkWidget *widget,
+                               gint height,
+                               gint *minimum,
+                               gint *natural)
+{
+    ddb_splitter_get_preferred_width (widget, minimum, natural);
+}
+
+static void
+ddb_splitter_get_preferred_height_for_width (GtkWidget *widget,
+                               gint width,
+                               gint *minimum,
+                               gint *natural)
+{
+    ddb_splitter_get_preferred_height (widget, minimum, natural);
+}
+#endif
+
+static void
+ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (widget);
+    GtkWidget *c1 = splitter->priv->child1;
+    GtkWidget *c2 = splitter->priv->child2;
+    // TODO: consider border width
+    gint border_width = 0;
+    gtk_widget_set_allocation (widget, allocation);
+
+    gboolean child1_visible = c1 && gtk_widget_get_visible (c1) ? TRUE : FALSE;
+    gboolean child2_visible = c2 && gtk_widget_get_visible (c2) ? TRUE : FALSE;
+    guint num_visible_children = child1_visible + child2_visible;
+
+    gint con_width = allocation->width - border_width * 2;
+    gint con_height = allocation->height - border_width * 2;
+    gint handle_size = 0;
+
+    GdkRectangle old_handle_pos = splitter->priv->handle_pos;
+
+    GtkAllocation child1_allocation;
+    GtkAllocation child2_allocation;
+    if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL) {
+        handle_size = num_visible_children > 1 ? splitter->priv->handle_size : 0;
+        if (child1_visible) {
+            // use full height in horitzontal splitter
+            child1_allocation.height = MAX (1, con_height);
+
+            gint width = 0;
+            if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C1) {
+                // child 1 locked, use saved size
+                width = splitter->priv->child1_size;
+            }
+            else {
+                if (num_visible_children == 1) {
+                    // only one child, use full width
+                    width = con_width;
+                }
+                else if (child2_visible && splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C2) {
+                    // two children and second one is locked, use all space left
+                    width = con_width - splitter->priv->child2_size - handle_size;
+                }
+                else {
+                    // two children visible and proportional scaling is active
+                    width = (con_width - handle_size) * splitter->priv->proportion;
+                }
+            }
+            child1_allocation.width = MAX (1, width);
+            child1_allocation.x =allocation->x + border_width;
+            child1_allocation.y = allocation->y + border_width;
+
+
+            gtk_widget_size_allocate (splitter->priv->child1, &child1_allocation);
+            splitter->priv->child1_size = child1_allocation.width;
+            if (splitter->priv->size_mode != DDB_SPLITTER_SIZE_MODE_PROP) {
+                splitter->priv->proportion = CLAMP ((float)child1_allocation.width/(con_width - handle_size), 0.0f, 1.0f);
+            }
+            splitter->priv->handle_pos.x = allocation->x + splitter->priv->child1_size + border_width;
+            splitter->priv->handle_pos.y = allocation->y + border_width;
+            splitter->priv->handle_pos.width = handle_size;
+            splitter->priv->handle_pos.height = MAX (1, allocation->height - 2 * border_width);
+
+        }
+        if (child2_visible) {
+            // use full height in horitzontal splitter
+            child2_allocation.height = MAX (1, con_height);
+            gint width = 0;
+            if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C2) {
+                // child 2 locked, use saved size
+                width = splitter->priv->child2_size;
+            }
+            else {
+                if (num_visible_children == 1) {
+                    // only one child, use full width
+                    width = con_width;
+                }
+                else if (child1_visible && splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C1) {
+                    // two children and first one is locked, use all space left
+                    width = con_width - splitter->priv->child1_size - handle_size;
+                }
+                else {
+                    // two children visible and proportional scaling is active
+                    width = con_width - child1_allocation.width - handle_size;
+                }
+            }
+            child2_allocation.width = MAX (1, width);
+            child2_allocation.x = child1_allocation.x + child1_allocation.width + handle_size;
+            child2_allocation.y = allocation->y + border_width;
+
+            gtk_widget_size_allocate (splitter->priv->child2, &child2_allocation);
+            splitter->priv->child2_size = child2_allocation.width;
+        }
+    }
+    else {
+        // splitter->priv->orientation == GTK_ORIENTATION_VERTICAL
+
+        handle_size = num_visible_children > 1 ? splitter->priv->handle_size : 0;
+        if (child1_visible) {
+            // use full width in vertical splitter
+            child1_allocation.width = MAX (1, con_width);
+
+            gint height = 0;
+            if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C1) {
+                // child 1 locked, use saved size
+                height = splitter->priv->child1_size;
+            }
+            else {
+                if (num_visible_children == 1) {
+                    // only one child, use full height
+                    height = con_height;
+                }
+                else if (child2_visible && splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C2) {
+                    // two children and second one is locked, use all space left
+                    height = con_height - splitter->priv->child2_size - handle_size;
+
+                }
+                else {
+                    // two children visible and proportional scaling is active
+                    height = (con_height - handle_size) * splitter->priv->proportion;
+                }
+            }
+            child1_allocation.height = MAX (1, height);
+            child1_allocation.x =allocation->x + border_width;
+            child1_allocation.y = allocation->y + border_width;
+
+            gtk_widget_size_allocate (splitter->priv->child1, &child1_allocation);
+            splitter->priv->child1_size = child1_allocation.height;
+            if (splitter->priv->size_mode != DDB_SPLITTER_SIZE_MODE_PROP) {
+                splitter->priv->proportion = CLAMP ((float)child1_allocation.height/(con_height - handle_size), 0.0f, 1.0f);
+            }
+            splitter->priv->handle_pos.x = allocation->x + border_width;
+            splitter->priv->handle_pos.y = allocation->y + splitter->priv->child1_size + border_width;
+            splitter->priv->handle_pos.width = MAX (1, (gint) allocation->width - 2 * border_width);
+            splitter->priv->handle_pos.height = handle_size;
+
+        }
+        if (child2_visible) {
+            // use full width in vertical splitter
+            child2_allocation.width = MAX (1, con_width);
+
+            gint height = 0;
+            if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C2) {
+                // child 2 locked, use saved size
+                height = splitter->priv->child2_size;
+            }
+            else {
+                if (num_visible_children == 1) {
+                    // only one child, use full height
+                    height = con_height;
+                }
+                else if (child1_visible && splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_LOCK_C1) {
+                    // two children and first one is locked, use all space left
+                    height = con_height - splitter->priv->child1_size - handle_size;
+                }
+                else {
+                    // two children visible and proportional scaling is active
+                    height = con_height - child1_allocation.height - handle_size;
+                }
+            }
+            child2_allocation.height = MAX (1, height);
+            child2_allocation.x = allocation->x + border_width;
+            child2_allocation.y = child1_allocation.y + child1_allocation.height + handle_size;
+
+            gtk_widget_size_allocate (splitter->priv->child2, &child2_allocation);
+            splitter->priv->child2_size = child2_allocation.height;
+        }
+    }
+
+    if (!child1_visible && !child2_visible) {
+        GtkAllocation child_allocation;
+
+        if (splitter->priv->child1)
+            gtk_widget_set_child_visible (splitter->priv->child1, TRUE);
+        if (splitter->priv->child2)
+            gtk_widget_set_child_visible (splitter->priv->child2, TRUE);
+
+        child_allocation.x = allocation->x + border_width;
+        child_allocation.y = allocation->y + border_width;
+        child_allocation.width = MAX (1, con_width);
+        child_allocation.height = MAX (1, con_height);
+
+        if (splitter->priv->child1 && gtk_widget_get_visible (splitter->priv->child1))
+            gtk_widget_size_allocate (splitter->priv->child1, &child_allocation);
+        else if (splitter->priv->child2 && gtk_widget_get_visible (splitter->priv->child2))
+            gtk_widget_size_allocate (splitter->priv->child2, &child_allocation);
+    }
+
+    if (gtk_widget_get_mapped (widget) &&
+            (old_handle_pos.x != splitter->priv->handle_pos.x ||
+             old_handle_pos.y != splitter->priv->handle_pos.y ||
+             old_handle_pos.width != splitter->priv->handle_pos.width ||
+             old_handle_pos.height != splitter->priv->handle_pos.height))
+    {
+        GdkWindow *window = gtk_widget_get_window (widget);
+        gdk_window_invalidate_rect (window, &old_handle_pos, FALSE);
+        gdk_window_invalidate_rect (window, &splitter->priv->handle_pos, FALSE);
+    }
+
+    if (gtk_widget_get_realized (widget)) {
+        if (gtk_widget_get_mapped (widget))
+            gdk_window_show (splitter->priv->handle);
+
+        if (splitter->priv->orientation == GTK_ORIENTATION_HORIZONTAL)
+        {
+            gdk_window_move_resize (splitter->priv->handle,
+                    splitter->priv->handle_pos.x,
+                    splitter->priv->handle_pos.y,
+                    handle_size,
+                    splitter->priv->handle_pos.height);
+        }
+        else {
+            gdk_window_move_resize (splitter->priv->handle,
+                    splitter->priv->handle_pos.x,
+                    splitter->priv->handle_pos.y,
+                    splitter->priv->handle_pos.width,
+                    handle_size);
+        }
+    }
+
+}
+
+static void
+ddb_splitter_add (GtkContainer *container, GtkWidget *widget)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (container);
+
+    if (splitter->priv->child1 && splitter->priv->child2) {
+        // Splitter already full
+        return;
+    }
+
+    gtk_widget_set_parent (widget, GTK_WIDGET (splitter));
+
+    if (!splitter->priv->child1) {
+        splitter->priv->child1 = widget;
+    }
+    else if (!splitter->priv->child2) {
+        splitter->priv->child2 = widget;
+    }
+
+    /* realize the widget if required */
+    if (gtk_widget_get_realized (GTK_WIDGET (container)))
+        gtk_widget_realize (widget);
+
+    /* map the widget if required */
+    if (gtk_widget_get_visible (GTK_WIDGET (container)) && gtk_widget_get_visible (widget))
+    {
+        if (gtk_widget_get_mapped (GTK_WIDGET (container)))
+            gtk_widget_map (widget);
+    }
+
+    gtk_widget_queue_resize (GTK_WIDGET (container));
+    return;
+}
+
+static void
+ddb_splitter_remove (GtkContainer *container, GtkWidget *widget)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (container);
+
+    /* check if the widget was visible */
+    gboolean widget_was_visible = gtk_widget_get_visible (widget);
+
+    /* unparent and remove the widget */
+    gtk_widget_unparent (widget);
+    if (splitter->priv->child1 == widget) {
+        splitter->priv->child1 = NULL;
+    }
+    else if (splitter->priv->child2 == widget) {
+        splitter->priv->child2 = NULL;
+    }
+
+    if (G_LIKELY (widget_was_visible))
+        gtk_widget_queue_resize (GTK_WIDGET (splitter));
+}
+
+static void
+ddb_splitter_forall (GtkContainer *container,
+                     gboolean include_internals,
+                     GtkCallback callback,
+                     gpointer callback_data)
+{
+    DdbSplitter *splitter = DDB_SPLITTER (container);
+    GtkWidget *c1 = splitter->priv->child1;
+    GtkWidget *c2 = splitter->priv->child2;
+
+    if (c1 && GTK_IS_WIDGET (c1)) {
+        (*callback) (c1, callback_data);
+    }
+    if (c2 && GTK_IS_WIDGET (c2)) {
+        (*callback) (c2, callback_data);
+    }
+}
+
+static void
+ddb_splitter_remove_child (DdbSplitter *splitter, guint child)
+{
+    if (child == 1 && splitter->priv->child1) {
+        ddb_splitter_remove (GTK_CONTAINER (splitter), splitter->priv->child1);
+    }
+    else if (child == 2 && splitter->priv->child2) {
+        ddb_splitter_remove (GTK_CONTAINER (splitter), splitter->priv->child2);
+    }
+}
+
+void
+ddb_splitter_remove_c1 (DdbSplitter *splitter)
+{
+    ddb_splitter_remove_child (splitter, 1);
+}
+
+void
+ddb_splitter_remove_c2 (DdbSplitter *splitter)
+{
+    ddb_splitter_remove_child (splitter, 2);
+}
+
+gboolean
+ddb_splitter_add_child_at_pos (DdbSplitter *splitter, GtkWidget *child, guint pos)
+{
+    if (pos == 0 && !splitter->priv->child1) {
+        splitter->priv->child1 = child;
+    }
+    else if (pos == 1 && !splitter->priv->child2) {
+        splitter->priv->child2 = child;
+    }
+    else {
+        return FALSE;
+    }
+
+    gtk_widget_set_parent (child, GTK_WIDGET (splitter));
+    /* realize the widget if required */
+    if (gtk_widget_get_realized (GTK_WIDGET (splitter)))
+        gtk_widget_realize (child);
+
+    /* map the widget if required */
+    if (gtk_widget_get_visible (GTK_WIDGET (splitter)) && gtk_widget_get_visible (child))
+    {
+        if (gtk_widget_get_mapped (GTK_WIDGET (splitter)))
+            gtk_widget_map (child);
+    }
+
+    gtk_widget_queue_resize (GTK_WIDGET (splitter));
+    return TRUE;
+}
+
+/**
+ * ddb_splitter_get_size_mode:
+ * @splitter : a #DdbSplitter.
+ *
+ * Returns the size mode of the splitter
+ *
+ * Returns: the size mode of @splitter.
+ **/
+DdbSplitterSizeMode
+ddb_splitter_get_size_mode (const DdbSplitter *splitter)
+{
+    g_return_val_if_fail (DDB_IS_SPLITTER (splitter), DDB_SPLITTER_SIZE_MODE_PROP);
+    return splitter->priv->size_mode;
+}
+
+/**
+ * ddb_splitter_set_size_mode:
+ * @splitter    : a #DdbSplitter.
+ * @size_mode : The size_mode of the splitter.
+ *
+ * Sets the size_mode of the @splitter
+ **/
+void
+ddb_splitter_set_size_mode (DdbSplitter *splitter, DdbSplitterSizeMode size_mode)
+{
+    g_return_if_fail (DDB_IS_SPLITTER (splitter));
+
+    if (G_LIKELY (splitter->priv->size_mode != size_mode))
+    {
+        splitter->priv->size_mode = size_mode;
+        ddb_splitter_update_cursor (splitter);
+        gtk_widget_queue_resize (GTK_WIDGET (splitter));
+        g_object_notify (G_OBJECT (splitter), "size_mode");
+    }
+}
+
+/**
+ * ddb_splitter_get_orientation:
+ * @splitter : a #DdbSplitter.
+ *
+ * Returns the orientation of the splitter
+ *
+ * Returns: the orientation of @splitter.
+ **/
+GtkOrientation
+ddb_splitter_get_orientation (const DdbSplitter *splitter)
+{
+    g_return_val_if_fail (DDB_IS_SPLITTER (splitter), GTK_ORIENTATION_HORIZONTAL);
+    return splitter->priv->orientation;
+}
+
+/**
+ * ddb_splitter_set_orientation:
+ * @splitter    : a #DdbSplitter.
+ * @orientation : The orientation of the splitter.
+ *
+ * Sets the orientation of the @splitter
+ **/
+void
+ddb_splitter_set_orientation (DdbSplitter *splitter, GtkOrientation orientation)
+{
+    g_return_if_fail (DDB_IS_SPLITTER (splitter));
+
+    if (G_LIKELY (splitter->priv->orientation != orientation))
+    {
+        splitter->priv->orientation = orientation;
+        gtk_widget_queue_resize (GTK_WIDGET (splitter));
+        g_object_notify (G_OBJECT (splitter), "orientation");
+    }
+}
+
+/**
+ * ddb_splitter_get_proportion:
+ * @splitter : a #DdbSplitter.
+ *
+ * Returns the proportion of the splitter
+ *
+ * Returns: the proportion of the @splitter.
+ **/
+gfloat
+ddb_splitter_get_proportion (const DdbSplitter *splitter)
+{
+    g_return_val_if_fail (DDB_IS_SPLITTER (splitter), 0.f);
+    return splitter->priv->proportion;
+}
+
+/**
+ * ddb_splitter_set_proportion:
+ * @splitter    : a #DdbSplitter.
+ * @proportion : The proportion how the child should be arranged.
+ *
+ * Sets the proportion of the @splitter
+ **/
+void
+ddb_splitter_set_proportion (DdbSplitter *splitter, gfloat proportion)
+{
+    g_return_if_fail (DDB_IS_SPLITTER (splitter));
+
+    if (splitter->priv->size_mode == DDB_SPLITTER_SIZE_MODE_PROP
+           && G_LIKELY (splitter->priv->proportion != proportion))
+    {
+        splitter->priv->proportion = proportion;
+        gtk_widget_queue_resize (GTK_WIDGET (splitter));
+        g_object_notify (G_OBJECT (splitter), "proportion");
+    }
+}
+
+guint
+ddb_splitter_get_child1_size (DdbSplitter *splitter)
+{
+    return splitter->priv->child1_size;
+}
+
+guint
+ddb_splitter_get_child2_size (DdbSplitter *splitter)
+{
+    return splitter->priv->child2_size;
+}
+
+void
+ddb_splitter_set_child1_size (DdbSplitter *splitter, guint size)
+{
+    g_return_if_fail (DDB_IS_SPLITTER (splitter));
+
+    splitter->priv->child1_size = size;
+    gtk_widget_queue_resize (GTK_WIDGET (splitter));
+}
+
+void
+ddb_splitter_set_child2_size (DdbSplitter *splitter, guint size)
+{
+    g_return_if_fail (DDB_IS_SPLITTER (splitter));
+
+    splitter->priv->child2_size = size;
+    gtk_widget_queue_resize (GTK_WIDGET (splitter));
+}
+
+/* Return a new PSquare cast to a GtkWidget */
+GtkWidget *
+ddb_splitter_new(GtkOrientation orientation)
+{
+    return GTK_WIDGET (g_object_new (ddb_splitter_get_type (), "orientation", orientation, NULL));
+}

--- a/plugins/gtkui/ddb_splitter.c
+++ b/plugins/gtkui/ddb_splitter.c
@@ -824,6 +824,8 @@ ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
     DdbSplitter *splitter = DDB_SPLITTER (widget);
     GtkWidget *c1 = splitter->priv->child1;
     GtkWidget *c2 = splitter->priv->child2;
+
+    gfloat old_proportion = splitter->priv->proportion;
     // TODO: consider border width
     gint border_width = 0;
     gtk_widget_set_allocation (widget, allocation);
@@ -1037,6 +1039,11 @@ ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
         }
     }
 
+    g_object_freeze_notify (G_OBJECT (splitter));
+    if (splitter->priv->proportion != old_proportion) {
+        g_object_notify (G_OBJECT (splitter), "proportion");
+    }
+    g_object_thaw_notify (G_OBJECT (splitter));
 }
 
 static void

--- a/plugins/gtkui/ddb_splitter.c
+++ b/plugins/gtkui/ddb_splitter.c
@@ -693,7 +693,8 @@ ddb_splitter_size_request (GtkWidget      *widget,
 {
     DdbSplitter *splitter = DDB_SPLITTER (widget);
 
-    gint border_width = 0;
+    gint border_width = gtk_container_get_border_width (GTK_CONTAINER (splitter));
+
     GtkRequisition req_c1;
     req_c1.width = 0;
     req_c1.height = 0;
@@ -826,8 +827,8 @@ ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
     GtkWidget *c2 = splitter->priv->child2;
 
     gfloat old_proportion = splitter->priv->proportion;
-    // TODO: consider border width
-    gint border_width = 0;
+
+    gint border_width = gtk_container_get_border_width (GTK_CONTAINER (splitter));
     gtk_widget_set_allocation (widget, allocation);
 
     gboolean child1_visible = c1 && gtk_widget_get_visible (c1) ? TRUE : FALSE;
@@ -868,7 +869,7 @@ ddb_splitter_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
                 }
             }
             child1_allocation.width = MAX (1, width);
-            child1_allocation.x =allocation->x + border_width;
+            child1_allocation.x = allocation->x + border_width;
             child1_allocation.y = allocation->y + border_width;
 
 

--- a/plugins/gtkui/ddb_splitter.h
+++ b/plugins/gtkui/ddb_splitter.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Christian Boxdörfer <christian.boxdoerfer@posteo.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#ifndef __DDB_SPLITTER_H__
+#define __DDB_SPLITTER_H__
+
+#include <gtk/gtk.h>
+#include "ddb_splitter_size_mode.h"
+
+G_BEGIN_DECLS
+
+typedef struct _DdbSplitterPrivate DdbSplitterPrivate;
+typedef struct _DdbSplitterClass   DdbSplitterClass;
+typedef struct _DdbSplitter        DdbSplitter;
+
+#define DDB_TYPE_SPLITTER             (ddb_splitter_get_type ())
+#define DDB_SPLITTER(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), DDB_TYPE_SPLITTER, DdbSplitter))
+#define DDB_SPLITTER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), DDB_TYPE_SPLITTER, DdbSplitterClass))
+#define DDB_IS_SPLITTER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), DDB_TYPE_SPLITTER))
+#define DDB_IS_SPLITTER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), DDB_TYPE_SPLITTER))
+#define DDB_SPLITTER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), DDB_TYPE_SPLITTER, DdbSplitterClass))
+
+struct _DdbSplitterClass
+{
+  /*< private >*/
+  GtkContainerClass __parent__;
+
+  /* padding for further expansion */
+  void (*reserved1) (void);
+  void (*reserved2) (void);
+  void (*reserved3) (void);
+  void (*reserved4) (void);
+};
+
+/**
+ * DdbSplitter:
+ *
+ *  The #DdbSplitter struct contains only private fields
+* and should not be directly accessed.
+ **/
+struct _DdbSplitter
+{
+  /*< private >*/
+  GtkContainer         __parent__;
+  DdbSplitterPrivate *priv;
+};
+
+GType
+ddb_splitter_get_type (void) G_GNUC_CONST;
+
+GtkWidget
+*ddb_splitter_new (GtkOrientation orientation);
+
+DdbSplitterSizeMode
+ddb_splitter_get_size_mode (const DdbSplitter *splitter);
+GtkOrientation
+ddb_splitter_get_orientation (const DdbSplitter *splitter);
+gfloat
+ddb_splitter_get_proportion (const DdbSplitter *splitter);
+void
+ddb_splitter_set_size_mode (DdbSplitter *splitter, DdbSplitterSizeMode size_mode);
+gboolean
+ddb_splitter_add_child_at_pos (DdbSplitter *splitter, GtkWidget *child, guint pos);
+void
+ddb_splitter_remove_c1 (DdbSplitter *splitter);
+void
+ddb_splitter_remove_c2 (DdbSplitter *splitter);
+void
+ddb_splitter_set_proportion (DdbSplitter *splitter, gfloat proportion);
+guint
+ddb_splitter_get_child1_size (DdbSplitter *splitter);
+guint
+ddb_splitter_get_child2_size (DdbSplitter *splitter);
+void
+ddb_splitter_set_child1_size (DdbSplitter *splitter, guint size);
+void
+ddb_splitter_set_child2_size (DdbSplitter *splitter, guint size);
+
+G_END_DECLS
+
+#endif /* !__DDB_SPLITTER_H__ */

--- a/plugins/gtkui/ddb_splitter_size_mode.c
+++ b/plugins/gtkui/ddb_splitter_size_mode.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 Christian Boxdörfer <christian.boxdoerfer@posteo.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#include "ddb_splitter_size_mode.h"
+
+GType
+ddb_splitter_size_mode_get_type (void)
+{
+    static GType type = G_TYPE_INVALID;
+
+    if (G_UNLIKELY (type == G_TYPE_INVALID))
+    {
+        static const GEnumValue values[] =
+        {
+            { DDB_SPLITTER_SIZE_MODE_PROP,   "DDB_SPLITTER_SIZE_MODE_PROP",   "Proportional sizing",       },
+            { DDB_SPLITTER_SIZE_MODE_LOCK_C1, "DDB_SPLITTER_SIZE_MODE_LOCK_C1", "Size of first child is locked",     },
+            { DDB_SPLITTER_SIZE_MODE_LOCK_C2,   "DDB_SPLITTER_SIZE_MODE_LOCK_C2", "Size of second child is locked", },
+            { 0, NULL, NULL, },
+        };
+
+        type = g_enum_register_static ("DdbSplitterSizeMode", values);
+    }
+
+    return type;
+}

--- a/plugins/gtkui/ddb_splitter_size_mode.h
+++ b/plugins/gtkui/ddb_splitter_size_mode.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Christian Boxdörfer <christian.boxdoerfer@posteo.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#ifndef __DDB_SPLITTER_SIZE_MODE_H__
+#define __DDB_SPLITTER_SIZE_MODE_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define DDB_SPLITTER_TYPE_SIZE_MODE (ddb_splitter_size_mode_get_type ())
+
+typedef enum
+{
+    DDB_SPLITTER_SIZE_MODE_PROP,
+    DDB_SPLITTER_SIZE_MODE_LOCK_C1,
+    DDB_SPLITTER_SIZE_MODE_LOCK_C2,
+} DdbSplitterSizeMode;
+
+GType ddb_splitter_size_mode_get_type (void) G_GNUC_CONST;
+
+G_END_DECLS
+
+#endif /* !__DDB_SPLITTER_SIZE_MODE_H__ */

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -1327,9 +1327,8 @@ w_splitter_remove (ddb_gtkui_widget_t *cont, ddb_gtkui_widget_t *child) {
     gtk_container_remove (GTK_CONTAINER (container), child->widget);
 }
 
-////// vsplitter widget
 void
-w_vsplitter_init (ddb_gtkui_widget_t *base) {
+w_splitter_init (ddb_gtkui_widget_t *base) {
     w_splitter_t *w = (w_splitter_t *)base;
 
     ddb_splitter_set_proportion (DDB_SPLITTER (w->box), w->prop);
@@ -1342,6 +1341,7 @@ w_vsplitter_init (ddb_gtkui_widget_t *base) {
     }
 }
 
+////// vsplitter widget
 ddb_gtkui_widget_t *
 w_vsplitter_create (void) {
     w_splitter_t *w = malloc (sizeof (w_splitter_t));
@@ -1354,7 +1354,7 @@ w_vsplitter_create (void) {
     w->base.get_container = w_splitter_get_container;
     w->base.load = w_splitter_load;
     w->base.save = w_splitter_save;
-    w->base.init = w_vsplitter_init;
+    w->base.init = w_splitter_init;
     w->base.initmenu = w_splitter_initmenu;
 
     w->base.widget = gtk_event_box_new ();
@@ -1374,20 +1374,6 @@ w_vsplitter_create (void) {
 }
 
 ////// hsplitter widget
-void
-w_hsplitter_init (ddb_gtkui_widget_t *base) {
-    w_splitter_t *w = (w_splitter_t *)base;
-
-    ddb_splitter_set_proportion (DDB_SPLITTER (w->box), w->prop);
-    ddb_splitter_set_size_mode (DDB_SPLITTER (w->box), w->locked);
-    if (w->locked == DDB_SPLITTER_SIZE_MODE_LOCK_C1) {
-        ddb_splitter_set_child1_size (DDB_SPLITTER (w->box), w->size_c1);
-    }
-    else if (w->locked == DDB_SPLITTER_SIZE_MODE_LOCK_C2) {
-        ddb_splitter_set_child2_size (DDB_SPLITTER (w->box), w->size_c2);
-    }
-}
-
 ddb_gtkui_widget_t *
 w_hsplitter_create (void) {
     w_splitter_t *w = malloc (sizeof (w_splitter_t));
@@ -1400,7 +1386,7 @@ w_hsplitter_create (void) {
     w->base.get_container = w_splitter_get_container;
     w->base.load = w_splitter_load;
     w->base.save = w_splitter_save;
-    w->base.init = w_hsplitter_init;
+    w->base.init = w_splitter_init;
     w->base.initmenu = w_splitter_initmenu;
 
     w->base.widget = gtk_event_box_new ();

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -1185,6 +1185,10 @@ w_splitter_load (struct ddb_gtkui_widget_s *w, const char *type, const char *s) 
         else if (!strcmp (key, "size_c2")) {
             ((w_splitter_t *)w)->size_c2 = atoi (val);
         }
+        else if (!strcmp (key, "pos")) {
+            // import old pos value
+            ((w_splitter_t *)w)->size_c1 = atoi (val);
+        }
     }
 
     return s;


### PR DESCRIPTION
This pull request adds a new container widget (DdbSplitter, similar to GtkPaned) to the gtkui that's now used internally by the horizontal and vertical splitter (instead of GtkPaned and GtkBox). It works similar to the foobar2000 splitter widget.

The splitter widget now has the following config entries:
- `locked`
  - `0`: proportional scaling
  - `1`: lock size of first child
  - `2`: lock size of second child (new)
- `prop` (new)
  - `float_value` `[0.0, 1.0]`: the proportion value used in proportional scaling
- `size_c1` (new)
  - the size of the first child, this is the same as the old `pos` value and used to determine the size when child 1 is locked
- `size_c2` (new)
  - the size of the second child, used when child 2 is locked

The container has the following features:
- ability to hold up to two child widgets
- proportional scaling
- ability to lock the size of the first or second widget
- horizontal or vertical layout
- if no child is locked double click on splitter handle resets the handle pos to half the splitter width/height

This should fix the following issues: #1432 #975 #1378 #1469

