### PR TITLE
artwork: fix album art retrieval for m4a files.

### DIFF
--- a/plugins/artwork/Makefile.am
+++ b/plugins/artwork/Makefile.am
@@ -31,6 +31,6 @@ FLAC_DEPS=$(FLAC_LIBS)
 flac_cflags=-DUSE_METAFLAC $(FLAC_CFLAGS)
 endif
 
-AM_CFLAGS = $(CFLAGS) $(ARTWORK_CFLAGS) $(flac_cflags) $(artwork_net_cflags) $(ogg_def) -std=c99
-artwork_la_LIBADD = $(LDADD) $(ARTWORK_DEPS) $(FLAC_DEPS) $(ogg_libs)
+AM_CFLAGS = $(CFLAGS) $(ARTWORK_CFLAGS) $(flac_cflags) $(artwork_net_cflags) $(ogg_def) -DUSE_TAGGING -I@top_srcdir@/plugins/libmp4ff -std=c99
+artwork_la_LIBADD = $(LDADD) $(ARTWORK_DEPS) $(FLAC_DEPS) $(ogg_libs) ../libmp4ff/libmp4ff.a
 endif


### PR DESCRIPTION
1. Add function to mp4ff for handling binary blobs.
	- Previously mp4ff assume all tags are C string, which is not true for
	  album arts.
2. Add mp4_extract_art to artwork plugin to utilize mp4ff.
3. Link mp4ff to artwork plugin, now libmp4ff is mandatory for artwork.

Additional notes for PR:
It seems mp4ff uses a mixed coding style so I kept the original tabs unchanged.