### PR TITLE
gtkui: add copy/paste support

### DIFF
--- a/plugins/gtkui/Makefile.am
+++ b/plugins/gtkui/Makefile.am
@@ -37,6 +37,7 @@ GTKUI_SOURCES =    gtkui.c gtkui.h\
                    tfimport.c tfimport.h\
                    ddb_splitter.c ddb_splitter.h\
                    ddb_splitter_size_mode.c ddb_splitter_size_mode.h\
+                   clipboard.c clipboard.h\
 				   $(SM_SOURCES) $(OSXSRC)
 
 sdkdir = $(pkgincludedir)

--- a/plugins/gtkui/clipboard.c
+++ b/plugins/gtkui/clipboard.c
@@ -73,6 +73,7 @@ clipboard_free_clipboard_data ()
         }
         if (current_clipboard_data->plt_title) {
             free (current_clipboard_data->plt_title);
+            current_clipboard_data->plt_title = NULL;
         }
         current_clipboard_data->num_tracks = 0;
         current_clipboard_data->cut = 0;
@@ -149,8 +150,6 @@ clipboard_clear_clipboard_data (GtkClipboard *clipboard,
             for (int i = 0; i < clip_ctx->num_tracks; i++) {
                 if (clip_ctx->tracks[i]) {
                     deadbeef->pl_item_unref (clip_ctx->tracks[i]);
-                    if (clip_ctx->tracks[i]) {
-                    }
                 }
             }
             free (clip_ctx->tracks);

--- a/plugins/gtkui/clipboard.c
+++ b/plugins/gtkui/clipboard.c
@@ -203,8 +203,8 @@ clipboard_get_selected_tracks (clipboard_data_context_t *ctx, ddb_playlist_t *pl
     DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_MAIN);
     while (it) {
         if (deadbeef->pl_is_selected (it) && n < num) {
-            ctx->tracks[n] = deadbeef->pl_item_alloc ();
-            deadbeef->pl_item_copy (ctx->tracks[n++], it);
+            deadbeef->pl_item_ref (it);
+            ctx->tracks[n++] = it;
         }
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
@@ -245,8 +245,8 @@ clipboard_get_all_tracks (clipboard_data_context_t *ctx, ddb_playlist_t *plt)
     int n = 0;
     DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_MAIN);
     while (it) {
-        ctx->tracks[n] = deadbeef->pl_item_alloc ();
-        deadbeef->pl_item_copy (ctx->tracks[n++], it);
+        deadbeef->pl_item_ref (it);
+        ctx->tracks[n++] = it;
         DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
         deadbeef->pl_item_unref (it);
         it = next;
@@ -284,22 +284,6 @@ clipboard_delete_playlist (ddb_playlist_t *plt)
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     }
 }
-
-/* NOTE: in the current implementation copy/paste might require lots of memory
-   because all selected tracks get copied in memory to improve pasting speed.
-
-   The problem is:
-   playlist items are bound to a playlist, so when we copy a track and that
-   track gets deleted before a paste happend the data of the playlist item
-   might already be freed. So we have to copy that data in advance, which means we
-   have two copies of the same data in memory.
-
-   Of course we could fix that by storing the tracks' path instead and handle
-   a paste just like adding files or folders to a playlist. However this is quite slow
-   since we need to decode the tracks all over again.
-
-   As soon as we have a database we could improve that, because tracks would
-   be bound to the database and not the playlist and therefore be more persitent. */
 
 void
 clipboard_cut_selection (ddb_playlist_t *plt, int ctx) {

--- a/plugins/gtkui/clipboard.c
+++ b/plugins/gtkui/clipboard.c
@@ -1,0 +1,549 @@
+/*
+    Clipboard management
+    Copyright (C) 2016 Christian Boxdörfer
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <string.h>
+#include <gtk/gtk.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "../../gettext.h"
+#include "../../deadbeef.h"
+#include "gtkui.h"
+#include "ddblistview.h"
+#include <sys/stat.h>
+
+typedef struct {
+    char *plt_title;
+    DB_playItem_t **tracks;
+    int num_tracks;
+    int cut;
+} clipboard_data_context_t;
+
+static clipboard_data_context_t *current_clipboard_data = NULL;
+
+enum {
+    DDB_URI_LIST = 1,
+    URI_LIST,
+    GNOME_COPIED_FILES,
+    N_CLIPBOARD_TARGETS
+};
+
+static GtkTargetEntry targets[]=
+{
+    {"DDB_URI_LIST", GTK_TARGET_SAME_WIDGET, TARGET_SAMEWIDGET},
+    {"text/uri-list", 0, URI_LIST},
+    {"x-special/gnome-copied-files", 0, GNOME_COPIED_FILES},
+};
+
+void
+clipboard_free_clipboard_data ()
+{
+    if (current_clipboard_data) {
+        if (current_clipboard_data->tracks) {
+            for (int i = 0; i < current_clipboard_data->num_tracks; i++) {
+                if (current_clipboard_data->tracks[i]) {
+                    deadbeef->pl_item_unref (current_clipboard_data->tracks[i]);
+                }
+            }
+            free (current_clipboard_data->tracks);
+            current_clipboard_data->tracks = NULL;
+        }
+        if (current_clipboard_data->plt_title) {
+            free (current_clipboard_data->plt_title);
+        }
+        current_clipboard_data->num_tracks = 0;
+        current_clipboard_data->cut = 0;
+        free (current_clipboard_data);
+        current_clipboard_data = NULL;
+    }
+}
+
+static void
+clipboard_write_uri_list (clipboard_data_context_t *ctx, GString* buf)
+{
+    if (ctx->tracks && buf) {
+        for (int i = 0; i < ctx->num_tracks; i++) {
+            char *str = g_filename_to_uri (deadbeef->pl_find_meta (ctx->tracks[i],":URI"), NULL, NULL);
+            g_string_append (buf, str);
+            g_free (str);
+            if (i < ctx->num_tracks - 1) {
+                g_string_append (buf, "\r\n");
+            }
+        }
+    }
+}
+
+static void
+clipboard_write_gnome_uri_list (clipboard_data_context_t *ctx, GString* buf)
+{
+    if (ctx->tracks && buf) {
+        for (int i = 0; i < ctx->num_tracks; i++) {
+            char *str = g_filename_to_uri (deadbeef->pl_find_meta (ctx->tracks[i],":URI"), NULL, NULL);
+            g_string_append (buf, str);
+            g_free (str);
+            if (i < ctx->num_tracks - 1) {
+                g_string_append_c (buf, '\n');
+            }
+        }
+    }
+}
+
+static void
+clipboard_get_clipboard_data (GtkClipboard *clip, GtkSelectionData *sel, guint info, gpointer user_data)
+{
+    clipboard_data_context_t *clip_ctx = (clipboard_data_context_t *)user_data;
+    GdkAtom target = gtk_selection_data_get_target (sel);
+
+    GString *uri_list = g_string_sized_new (clip_ctx->num_tracks * 256);
+    guchar *buf = NULL;
+    gint buf_len = 0;
+    if (info == TARGET_SAMEWIDGET) {
+        buf = (guchar *)clip_ctx;
+        buf_len = sizeof (clipboard_data_context_t);
+    }
+    else if (info == GNOME_COPIED_FILES) {
+        g_string_append (uri_list, clip_ctx->cut ? "cut\n" : "copy\n");
+        clipboard_write_gnome_uri_list (clip_ctx, uri_list);
+        buf = (guchar *)uri_list->str;
+        buf_len = uri_list->len + 1;
+    }
+    else /* text/uri-list format */ {
+        clipboard_write_uri_list (clip_ctx, uri_list);
+        buf = (guchar *)uri_list->str;
+        buf_len = uri_list->len + 1;
+    }
+    gtk_selection_data_set (sel, target, 8, buf, buf_len);
+    g_string_free (uri_list, TRUE);
+}
+
+static void
+clipboard_clear_clipboard_data (GtkClipboard *clipboard,
+                             gpointer      user_data)
+{
+    clipboard_data_context_t *clip_ctx = (clipboard_data_context_t *)user_data;
+    if (clip_ctx) {
+        if (clip_ctx->tracks) {
+            for (int i = 0; i < clip_ctx->num_tracks; i++) {
+                if (clip_ctx->tracks[i]) {
+                    deadbeef->pl_item_unref (clip_ctx->tracks[i]);
+                    if (clip_ctx->tracks[i]) {
+                    }
+                }
+            }
+            free (clip_ctx->tracks);
+            clip_ctx->tracks = NULL;
+        }
+        if (clip_ctx->plt_title) {
+            free (clip_ctx->plt_title);
+            clip_ctx->plt_title = NULL;
+        }
+        clip_ctx->num_tracks = 0;
+        clip_ctx->cut = 0;
+        free (clip_ctx);
+        clip_ctx = NULL;
+    }
+}
+
+static gboolean
+clipboard_cut_or_copy_files (GtkWidget* src_widget, clipboard_data_context_t *ctx)
+{
+    GdkDisplay *display = src_widget ? gtk_widget_get_display (src_widget) : gdk_display_get_default();
+    GtkClipboard *clipboard = gtk_clipboard_get_for_display (display, GDK_SELECTION_CLIPBOARD);
+    gboolean ret;
+    ret = gtk_clipboard_set_with_data (clipboard, targets, G_N_ELEMENTS(targets),
+                                      clipboard_get_clipboard_data, clipboard_clear_clipboard_data, ctx);
+    return ret;
+}
+
+static gboolean
+clipboard_get_selected_tracks (clipboard_data_context_t *ctx, ddb_playlist_t *plt)
+{
+    if (plt == NULL) {
+        return FALSE;
+    }
+
+    deadbeef->pl_lock ();
+    int num = deadbeef->plt_getselcount (plt);
+
+    if (num <= 0) {
+        deadbeef->pl_unlock ();
+        return FALSE;
+    }
+
+    ctx->tracks = malloc (sizeof (DB_playItem_t *) * num);
+    if (!ctx->tracks) {
+        fprintf (stderr, "gtkui: failed to alloc %d bytes to store selected tracks\n", (int)(num * sizeof (void *)));
+        deadbeef->pl_unlock ();
+        return FALSE;
+    }
+
+    int n = 0;
+    DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_MAIN);
+    while (it) {
+        if (deadbeef->pl_is_selected (it) && n < num) {
+            ctx->tracks[n] = deadbeef->pl_item_alloc ();
+            deadbeef->pl_item_copy (ctx->tracks[n++], it);
+        }
+        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+        deadbeef->pl_item_unref (it);
+        it = next;
+    }
+    ctx->num_tracks = num;
+
+    deadbeef->pl_unlock ();
+    return TRUE;
+}
+
+static gboolean
+clipboard_get_all_tracks (clipboard_data_context_t *ctx, ddb_playlist_t *plt)
+{
+    if (plt == NULL) {
+        return FALSE;
+    }
+
+    deadbeef->pl_lock ();
+
+    char plt_title[1000] = "";
+    deadbeef->plt_get_title (plt, plt_title, sizeof (plt_title));
+    ctx->plt_title = strdup (plt_title);
+    int num_tracks = deadbeef->plt_get_item_count (plt, PL_MAIN);
+
+    if (num_tracks <= 0) {
+        deadbeef->pl_unlock ();
+        return FALSE;
+    }
+
+    ctx->tracks = malloc (sizeof (DB_playItem_t *) * num_tracks);
+    if (!ctx->tracks) {
+        fprintf (stderr, "gtkui: failed to alloc %d bytes to store playlist tracks\n", (int)(num_tracks * sizeof (void *)));
+        deadbeef->pl_unlock ();
+        return FALSE;
+    }
+
+    int n = 0;
+    DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_MAIN);
+    while (it) {
+        ctx->tracks[n] = deadbeef->pl_item_alloc ();
+        deadbeef->pl_item_copy (ctx->tracks[n++], it);
+        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+        deadbeef->pl_item_unref (it);
+        it = next;
+    }
+    ctx->num_tracks = num_tracks;
+
+    deadbeef->pl_unlock ();
+    return TRUE;
+}
+
+static void
+clipboard_delete_selected_tracks (ddb_playlist_t *plt)
+{
+    if (plt == NULL) {
+        return;
+    }
+
+    int total_count = deadbeef->plt_get_item_count (plt, PL_MAIN);
+    int cursor = deadbeef->plt_delete_selected (plt);
+
+    deadbeef->plt_set_cursor (plt, PL_MAIN, cursor);
+    deadbeef->plt_save_config (plt);
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+}
+
+static void
+clipboard_delete_playlist (ddb_playlist_t *plt)
+{
+    if (plt == NULL) {
+        return;
+    }
+    int idx = deadbeef->plt_get_idx (plt);
+    if (idx != -1) {
+        deadbeef->plt_remove (idx);
+        deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    }
+}
+
+/* NOTE: in the current implementation copy/paste might require lots of memory
+   because all selected tracks get copied in memory to improve pasting speed.
+
+   The problem is:
+   playlist items are bound to a playlist, so when we copy a track and that
+   track gets deleted before a paste happend the data of the playlist item
+   might already be freed. So we have to copy that data in advance, which means we
+   have two copies of the same data in memory.
+
+   Of course we could fix that by storing the tracks' path instead and handle
+   a paste just like adding files or folders to a playlist. However this is quite slow
+   since we need to decode the tracks all over again.
+
+   As soon as we have a database we could improve that, because tracks would
+   be bound to the database and not the playlist and therefore be more persitent. */
+
+void
+clipboard_cut_selection (ddb_playlist_t *plt, int ctx) {
+
+    if (plt == NULL) {
+        return;
+    }
+
+    clipboard_data_context_t *clip_ctx = malloc (sizeof (clipboard_data_context_t));
+
+    // save ptr to free on exit
+    current_clipboard_data = clip_ctx;
+
+    clip_ctx->plt_title = NULL;
+
+    int result = 0;
+    if (ctx == DDB_ACTION_CTX_SELECTION) {
+        result = clipboard_get_selected_tracks (clip_ctx, plt);
+        if (result) {
+            clipboard_delete_selected_tracks (plt);
+        }
+    }
+    else if (ctx == DDB_ACTION_CTX_PLAYLIST) {
+        result = clipboard_get_all_tracks (clip_ctx, plt);
+        if (result) {
+            clipboard_delete_playlist (plt);
+        }
+    }
+
+    if (result) {
+        clip_ctx->cut = 0;
+        clipboard_cut_or_copy_files (mainwin, clip_ctx);
+    }
+}
+
+void
+clipboard_copy_selection (ddb_playlist_t *plt, int ctx) {
+    if (plt == NULL) {
+        return;
+    }
+
+    clipboard_data_context_t *clip_ctx = malloc (sizeof (clipboard_data_context_t));
+
+    // save ptr to free on exit
+    current_clipboard_data = clip_ctx;
+
+    clip_ctx->plt_title = NULL;
+
+    int result = 0;
+    if (ctx == DDB_ACTION_CTX_SELECTION) {
+        result = clipboard_get_selected_tracks (clip_ctx, plt);
+    }
+    else if (ctx == DDB_ACTION_CTX_PLAYLIST) {
+        result = clipboard_get_all_tracks (clip_ctx, plt);
+    }
+
+    if (result) {
+        clip_ctx->cut = 0;
+        clipboard_cut_or_copy_files (mainwin, clip_ctx);
+    }
+}
+
+static void
+clipboard_activate_dest_playlist (const char *pdata, ddb_playlist_t *plt, int ctx)
+{
+    if (plt == NULL) {
+        // no playlist set, use current one
+        deadbeef->plt_set_curr (plt);
+        return;
+    }
+    clipboard_data_context_t *clip_ctx = (clipboard_data_context_t *)pdata;
+    if (ctx == DDB_ACTION_CTX_PLAYLIST) {
+        int playlist = -1;
+        if (clip_ctx && clip_ctx->plt_title) {
+            int cnt = deadbeef->plt_get_count ();
+            playlist = deadbeef->plt_add (cnt, clip_ctx->plt_title);
+        }
+        else {
+            playlist = gtkui_add_new_playlist ();
+        }
+        if (playlist != -1) {
+            gtkui_playlist_set_curr (playlist);
+        }
+    }
+}
+
+static void
+clipboard_received_uri_list (const char *pdata, int length)
+{
+    ddb_playlist_t *plt = deadbeef->plt_get_curr ();
+    if (plt) {
+        int cursor = deadbeef->plt_get_cursor (plt, PL_MAIN);
+        DB_playItem_t *it = deadbeef->pl_get_for_idx_and_iter (cursor, PL_MAIN);
+        if (it) {
+            gchar *ptr = (char *)pdata;
+            if (ptr && length > 0) {
+                char *mem = malloc (length+1);
+                memcpy (mem, ptr, length);
+                mem[length] = 0;
+                // use drop procedure
+                gtkui_receive_fm_drop (it, mem, length);
+            }
+            deadbeef->pl_item_unref (it);
+        }
+        deadbeef->plt_unref (plt);
+    }
+}
+
+static void
+clipboard_received_ddb_uri_list (const char *pdata)
+{
+    clipboard_data_context_t *ctx = (clipboard_data_context_t *)pdata;
+    DB_playItem_t **tracks = ctx->tracks;
+    int num_tracks = ctx->num_tracks;
+    if (!tracks || num_tracks <= 0) {
+        return;
+    }
+    deadbeef->pl_lock ();
+
+    ddb_playlist_t *plt = deadbeef->plt_get_curr ();
+
+    if (plt) {
+        int insert_pos = MAX (-1, deadbeef->plt_get_cursor (plt, PL_MAIN) - 1);
+        deadbeef->plt_deselect_all (plt);
+        for (int i = 0; i < num_tracks; i++) {
+            DB_playItem_t *it = tracks[i];
+            if (!it) {
+                printf ("gtkui paste: warning: item %d not found\n", i);
+                continue;
+            }
+            DB_playItem_t *it_new = deadbeef->pl_item_alloc ();
+            deadbeef->pl_item_copy (it_new, it);
+            deadbeef->pl_set_selected (it_new, 1);
+
+            DB_playItem_t *after = deadbeef->pl_get_for_idx_and_iter (insert_pos++, PL_MAIN);
+            deadbeef->plt_insert_item (plt, after, it_new);
+            deadbeef->pl_item_unref (it_new);
+            if (after) {
+                deadbeef->pl_item_unref (after);
+            }
+        }
+        deadbeef->pl_unlock ();
+        deadbeef->plt_save_config (plt);
+        deadbeef->plt_unref (plt);
+    }
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+}
+
+static GdkAtom target_atom[N_CLIPBOARD_TARGETS];
+
+static gboolean got_atoms = FALSE;
+
+static void
+clipboard_check_atoms (void)
+{
+    if (!got_atoms) {
+        for (int i = 0; i < N_CLIPBOARD_TARGETS; i++) {
+            target_atom[i] = GDK_NONE;
+        }
+        for (int i = 0; i < G_N_ELEMENTS (targets); i++) {
+            target_atom[targets[i].info] = gdk_atom_intern_static_string (targets[i].target);
+        }
+        got_atoms = TRUE;
+    }
+}
+
+void
+clipboard_paste_selection (ddb_playlist_t *plt, int ctx)
+{
+    if (!plt) {
+        return;
+    }
+    GdkDisplay *display = mainwin ? gtk_widget_get_display (mainwin) : gdk_display_get_default();
+    GtkClipboard *clip = gtk_clipboard_get_for_display (display, GDK_SELECTION_CLIPBOARD);
+    int type = 0;
+    GdkAtom *avail_targets = NULL;
+    int n = 0;
+
+    // get all available targets currently in the clipboard.
+    if (!gtk_clipboard_wait_for_targets (clip, &avail_targets, &n)) {
+        return;
+    }
+
+    clipboard_check_atoms ();
+
+    // we prefer DDB_URI_LIST, so first check all tragets for that
+    for (int i = 0; i < n; i++) {
+        if (avail_targets[i] == target_atom[DDB_URI_LIST]) {
+            type = DDB_URI_LIST;
+            break;
+        }
+    }
+    if (type == 0) {
+        // no DDB_URI_LIST, check for other supported targets
+        for (int i = 0; i < n; i++) {
+            if (avail_targets[i] == target_atom[GNOME_COPIED_FILES]) {
+                type = GNOME_COPIED_FILES;
+                break;
+            }
+            else if (avail_targets[i] == target_atom[URI_LIST]) {
+                type = URI_LIST;
+                break;
+            }
+        }
+    }
+    g_free (avail_targets);
+
+    if (type) {
+        GtkSelectionData *data = gtk_clipboard_wait_for_contents (clip, target_atom[type]);
+        const gchar *pdata = (const gchar *)gtk_selection_data_get_data (data);
+        gint data_len = gtk_selection_data_get_length (data);
+
+        switch (type) {
+            case DDB_URI_LIST:
+                clipboard_activate_dest_playlist (pdata, plt, ctx);
+                clipboard_received_ddb_uri_list (pdata);
+                break;
+            case GNOME_COPIED_FILES:
+                clipboard_activate_dest_playlist (NULL, plt, ctx);
+                clipboard_received_uri_list (pdata, data_len);
+                break;
+            case URI_LIST:
+                clipboard_activate_dest_playlist (NULL, plt, ctx);
+                clipboard_received_uri_list (pdata, data_len);
+                break;
+            default:
+                break;
+        }
+        gtk_selection_data_free (data);
+    }
+}
+
+int
+clipboard_is_clipboard_data_available ()
+{
+    GdkDisplay *display = mainwin ? gtk_widget_get_display (mainwin) : gdk_display_get_default();
+    GtkClipboard *clipboard = gtk_clipboard_get_for_display (display, GDK_SELECTION_CLIPBOARD);
+    clipboard_check_atoms ();
+    for (int i = 0; i < N_CLIPBOARD_TARGETS; i++) {
+        if (gtk_clipboard_wait_is_target_available (clipboard, target_atom[i])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+

--- a/plugins/gtkui/clipboard.h
+++ b/plugins/gtkui/clipboard.h
@@ -1,0 +1,44 @@
+/*
+    Clipboard management
+    Copyright (C) Christian Boxdörfer
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef __CLIPBOARD_H
+#define __CLIPBOARD_H
+
+#include "../../deadbeef.h"
+
+void
+clipboard_free_clipboard_data ();
+
+void
+clipboard_cut_selection (ddb_playlist_t *plt, int ctx);
+
+void
+clipboard_copy_selection (ddb_playlist_t *plt, int ctx);
+
+void
+clipboard_paste_selection (ddb_playlist_t *plt, int ctx);
+
+int
+clipboard_is_clipboard_data_available ();
+
+#endif

--- a/plugins/gtkui/clipboard.h
+++ b/plugins/gtkui/clipboard.h
@@ -27,7 +27,7 @@
 #include "../../deadbeef.h"
 
 void
-clipboard_free_clipboard_data ();
+clipboard_free_current ();
 
 void
 clipboard_cut_selection (ddb_playlist_t *plt, int ctx);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -102,9 +102,11 @@ typedef struct {
     void (*col_free_user_data) (void *user_data);
 
     // callbacks
-    void (*list_context_menu) (DdbListview *listview, DdbListviewIter iter, int idx);
+    void (*list_context_menu) (DdbListview *listview, DdbListviewIter iter, int idx, int plt_iter);
+    void (*list_empty_region_context_menu) (DdbListview *listview);
     void (*header_context_menu) (DdbListview *listview, int col);
     void (*handle_doubleclick) (DdbListview *listview, DdbListviewIter iter, int idx);
+    gboolean (*list_handle_keypress) (DdbListview *ps, int keyval, int state, int iter);
     void (*selection_changed) (DdbListview *listview, DdbListviewIter it, int idx);
     void (*delete_selected) (void);
     void (*groups_changed) (const char *format);
@@ -215,10 +217,10 @@ void
 ddb_listview_set_binding (DdbListview *listview, DdbListviewBinding *binding);
 void
 ddb_listview_draw_row (DdbListview *listview, int idx, DdbListviewIter iter);
-int
-ddb_listview_handle_keypress (DdbListview *ps, int keyval, int state);
 void
 ddb_listview_select_single (DdbListview *listview, int sel);
+void
+ddb_listview_select_range (DdbListview *ps, int start, int end);
 void
 ddb_listview_scroll_to (DdbListview *listview, int rowpos);
 int
@@ -275,6 +277,11 @@ ddb_listview_groupcheck (DdbListview *listview);
 void
 ddb_listview_cancel_autoredraw (DdbListview *listview);
 
+void
+ddb_listview_update_cursor (DdbListview *ps, int cursor);
+
+void
+ddb_listview_set_cursor_and_scroll (DdbListview *listview, int cursor);
 G_END_DECLS
 
 #endif // __DDBLISTVIEW_H

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -1167,7 +1167,7 @@ gtkui_thread (void *ctx) {
         refresh_timeout = 0;
     }
 
-    clipboard_free_clipboard_data ();
+    clipboard_free_current ();
     cover_art_free ();
     eq_window_destroy ();
     trkproperties_destroy ();

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -62,6 +62,7 @@
 #include "retina.h"
 #endif
 #include "actionhandlers.h"
+#include "clipboard.h"
 #include "hotkeys.h"
 #include "../hotkeys/hotkeys.h"
 
@@ -1165,6 +1166,8 @@ gtkui_thread (void *ctx) {
         g_source_remove (refresh_timeout);
         refresh_timeout = 0;
     }
+
+    clipboard_free_clipboard_data ();
     cover_art_free ();
     eq_window_destroy ();
     trkproperties_destroy ();
@@ -1770,4 +1773,7 @@ static ddb_gtkui_t plugin = {
     .mainwin_toggle_visible = mainwin_toggle_visible,
     .show_traymenu = show_traymenu,
     .override_builtin_statusicon = override_builtin_statusicon,
+    .copy_selection = clipboard_copy_selection,
+    .cut_selection = clipboard_cut_selection,
+    .paste_selection = clipboard_paste_selection,
 };

--- a/plugins/gtkui/gtkui_api.h
+++ b/plugins/gtkui/gtkui_api.h
@@ -260,6 +260,14 @@ typedef struct {
     // plugin wants to make it in a different way
     void (*override_builtin_statusicon) (int override_);
 #endif
+#if (DDB_GTKUI_API_LEVEL >= 204)
+    // copy and paste actions
+    // plt_idx: the playlist to copy/cut from or paste to
+    // ctx: DDB_ACTION_CTX_SELECTION to copy/cut/paste tracks, DDB_ACTION_CTX_PLAYLIST to copy/cut/paste a playlist
+    void (*copy_selection) (ddb_playlist_t *plt, int ctx);
+    void (*cut_selection) (ddb_playlist_t *plt, int ctx);
+    void (*paste_selection) (ddb_playlist_t *plt, int ctx);
+#endif
 } ddb_gtkui_t;
 
 #endif

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -197,9 +197,11 @@ static DdbListviewBinding main_binding = {
 
     // callbacks
     .handle_doubleclick = main_handle_doubleclick,
+    .list_handle_keypress = list_handle_keypress,
     .selection_changed = main_selection_changed,
     .header_context_menu = pl_common_header_context_menu,
-    .list_context_menu = pl_common_list_context_menu,
+    .list_context_menu = list_context_menu,
+    .list_empty_region_context_menu = list_empty_region_context_menu,
     .delete_selected = main_delete_selected,
     .vscroll_changed = main_vscroll_changed,
     .modification_idx = gtkui_get_curr_playlist_mod,

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -44,10 +44,16 @@ void
 pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
 
 void
-pl_common_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int iter, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height);
+list_context_menu (DdbListview *listview, DdbListviewIter it, int idx, int iter);
 
 void
-pl_common_list_context_menu (DdbListview *listview, DdbListviewIter it, int idx);
+list_empty_region_context_menu (DdbListview *listview);
+
+gboolean
+list_handle_keypress (DdbListview *ps, int keyval, int state, int iter);
+
+void
+pl_common_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int iter, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height);
 
 int
 pl_common_load_column_config (DdbListview *listview, const char *key);

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -29,7 +29,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include "gtkui.h"
-#include "actionhandlers.h"
 #include "clipboard.h"
 #include "interface.h"
 #include "support.h"

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -575,6 +575,16 @@ search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIt
     pl_common_draw_group_title (listview, drawable, it, PL_SEARCH, x, y, width, height);
 }
 
+void
+search_list_context_menu (DdbListview *listview, DdbListviewIter it, int idx, int iter) {
+    list_context_menu (listview, it, idx, PL_SEARCH);
+}
+
+gboolean
+search_list_handle_keypress (DdbListview *ps, int keyval, int state, int iter) {
+    return list_handle_keypress (ps, keyval, state, PL_SEARCH);
+}
+
 static DdbListviewBinding search_binding = {
     // rows
     .count = search_get_count,
@@ -609,9 +619,11 @@ static DdbListviewBinding search_binding = {
 
     // callbacks
     .handle_doubleclick = search_handle_doubleclick,
+    .list_handle_keypress = search_list_handle_keypress,
     .selection_changed = search_selection_changed,
     .header_context_menu = pl_common_header_context_menu,
-    .list_context_menu = pl_common_list_context_menu,
+    .list_context_menu = search_list_context_menu,
+    .list_empty_region_context_menu = NULL,
     .delete_selected = search_delete_selected,
     .modification_idx = gtkui_get_curr_playlist_mod,
 };


### PR DESCRIPTION
This is quite a big patch so I don't expect it to get merged right away.

What this PR does: It adds copy, cut and paste support to the ddblistview, the pltbrowser and the pltmenu. C&P works both from DeaDBeeF to file managers and the other way around, and of course within DeaDBeeF (copy track(s) in playlist1 and paste it/them in playlist2). Pasting tracks to the pltbrowser first creates a new playlist and then pastes the tracks there. C&P can be triggered either via menu items or via shortcuts (ctrl+c, ctrl+x, ctrl+v).

To make C&P available to the pltbrowser plugin I added an API to the gtkui plugin:
https://github.com/Alexey-Yakovenko/deadbeef/compare/master...cboxdoerfer:copy_paste?expand=1#diff-31721c7ad41dcfea0c8abdd8072c53e9R263

Hope I can get any feedback on that. I also thought about making a proper GObject, e.g. DdbClipboard, but found that to much overhead, with little benefit.