### PR TITLE
Fix some untranslateable strings and use more consistent naming in Rename Tab and Playlist dialogs

### DIFF
--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -634,7 +634,7 @@ GtkWidget*
 title_formatting_help_link_create (gchar *widget_name, gchar *string1, gchar *string2,
                 gint int1, gint int2)
 {
-    GtkWidget *link = gtk_link_button_new_with_label ("http://github.com/Alexey-Yakovenko/deadbeef/wiki/Title-formatting-2.0", "Help");
+    GtkWidget *link = gtk_link_button_new_with_label ("http://github.com/Alexey-Yakovenko/deadbeef/wiki/Title-formatting-2.0", _("Help"));
     return link;
 }
 

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -60,7 +60,7 @@ on_rename_playlist1_activate           (GtkMenuItem     *menuitem,
 {
     GtkWidget *dlg = create_entrydialog ();
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
-    gtk_window_set_title (GTK_WINDOW (dlg), _("Edit playlist"));
+    gtk_window_set_title (GTK_WINDOW (dlg), _("Rename Playlist"));
     GtkWidget *e;
     e = lookup_widget (dlg, "title_label");
     gtk_label_set_text (GTK_LABEL(e), _("Title:"));

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -1525,7 +1525,7 @@ on_rename_tab_activate (GtkMenuItem *menuitem, gpointer user_data) {
 
     GtkWidget *dlg = create_entrydialog ();
     gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
-    gtk_window_set_title (GTK_WINDOW (dlg), _("Rename tab"));
+    gtk_window_set_title (GTK_WINDOW (dlg), _("Rename Tab"));
     GtkWidget *e;
     e = lookup_widget (dlg, "title_label");
     gtk_label_set_text (GTK_LABEL(e), _("Title:"));

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -409,9 +409,9 @@ on_pltbrowser_header_popup_menu (gpointer user_data)
 {
     w_pltbrowser_t *w = user_data;
     GtkWidget *popup = gtk_menu_new ();
-    GtkWidget *playing = gtk_check_menu_item_new_with_mnemonic ("Playing");
-    GtkWidget *items = gtk_check_menu_item_new_with_mnemonic ("Items");
-    GtkWidget *duration = gtk_check_menu_item_new_with_mnemonic ("Duration");
+    GtkWidget *playing = gtk_check_menu_item_new_with_mnemonic (_("Playing"));
+    GtkWidget *items = gtk_check_menu_item_new_with_mnemonic (_("Items"));
+    GtkWidget *duration = gtk_check_menu_item_new_with_mnemonic (_("Duration"));
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (playing), deadbeef->conf_get_int ("gtkui.pltbrowser.show_playing_column", 0));
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (items), deadbeef->conf_get_int ("gtkui.pltbrowser.show_items_column", 0));
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (duration), deadbeef->conf_get_int ("gtkui.pltbrowser.show_duration_column", 0));


### PR DESCRIPTION
This partially fixes #1503