### PR TITLE
Fix build failures on armv6

### DIFF
--- a/plugins/adplug/adplug/s3m.cpp
+++ b/plugins/adplug/adplug/s3m.cpp
@@ -26,7 +26,7 @@
 #include <string.h>
 #include "s3m.h"
 
-const char Cs3mPlayer::chnresolv[] =	// S3M -> adlib channel conversion
+const signed char Cs3mPlayer::chnresolv[] =	// S3M -> adlib channel conversion
   {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,0,1,2,3,4,5,6,7,8,-1,-1,-1,-1,-1,-1,-1};
 
 const unsigned short Cs3mPlayer::notetable[12] =		// S3M adlib note table

--- a/plugins/adplug/adplug/s3m.h
+++ b/plugins/adplug/adplug/s3m.h
@@ -92,7 +92,7 @@ class Cs3mPlayer: public CPlayer
   char filetype[30];
 
  private:
-  static const char chnresolv[];
+  static const signed char chnresolv[];
   static const unsigned short notetable[12];
   static const unsigned char vibratotab[32];
 

--- a/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp
+++ b/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.cpp
@@ -81,7 +81,7 @@ const int8_t XSID::sampleConvertTable[16] =
     '\x08', '\x19', '\x2a', '\x3b', '\x4c', '\x5d', '\x6e', '\x7f'
 };
 */
-const int8_t XSID::sampleConvertTable[16] =
+const uint8_t XSID::sampleConvertTable[16] =
 {
     '\x80', '\x94', '\xa9', '\xbc', '\xce', '\xe1', '\xf2', '\x03',
     '\x1b', '\x2a', '\x3b', '\x49', '\x58', '\x66', '\x73', '\x7f'

--- a/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h
+++ b/plugins/sid/sidplay-libs/libsidplay/src/xsid/xsid.h
@@ -234,7 +234,7 @@ private:
     uint8_t             sidData0x18;
     bool                _sidSamples;
     int8_t              sampleOffset;
-    static const int8_t sampleConvertTable[16];
+    static const uint8_t sampleConvertTable[16];
     bool                wasRunning;
 
 private:


### PR DESCRIPTION
This is the patch used for Alpine Linux to make deadbeef build on armv6
with hard-float ABI. Narrowing issues come from the fact that char on
ARM is unsigned by default, and GCC6 treats this as an error.

(As I'm not portability expert, it would be nice if someone wiser could take a look at this change.)