### PR TITLE
Avoid mktemp and use mkstemp instead

### DIFF
--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -919,7 +919,7 @@ convert (DB_playItem_t *it, const char *out, int output_bps, int output_is_float
                     tmp = "/tmp";
                 }
                 snprintf (input_file_name, sizeof (input_file_name), "%s/ddbconvXXXXXX", tmp);
-                char *res = mktemp (input_file_name);
+                char *res = mkstemp (input_file_name);
                 strcat (input_file_name, ".wav");
             }
             else {


### PR DESCRIPTION
As described in **man 3 mktemp**:
**Never  use mktemp()**.  Some implementations follow 4.3BSD and replace XXXXXX by the current process ID and a single letter, so that at most 26 different names can be returned.  Since on the one hand the names are easy to guess, and on  the  other  hand there  is a race between testing whether the name exists and opening the file, every use of mktemp() is a security risk.  The race is avoided by mkstemp(3) and mkdtemp(3).