### PR TITLE
start playing in stopped state on TOGGLE_PAUSE (fix issue #1642)

### DIFF
--- a/main.c
+++ b/main.c
@@ -649,7 +649,7 @@ player_mainloop (void) {
                     }
                     break;
                 case DB_EV_TOGGLE_PAUSE:
-                    if (output->state () == OUTPUT_STATE_PAUSED) {
+                    if (output->state () != OUTPUT_STATE_PLAYING) {
                         streamer_play_current_track ();
                     }
                     else {


### PR DESCRIPTION
trivial patch to let --play-pause start playing in stopped state, fixing issue #1642 