### PR TITLE
deadbeef.h: add logging api with va_list parameters

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -29,6 +29,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <dirent.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1276,9 +1277,15 @@ typedef struct {
     // See DDB_LOG_LAYER_* for details
     void (*log_detailed) (struct DB_plugin_s *plugin, uint32_t layers, const char *fmt, ...);
 
+    // Same as log_detailed but uses va_list
+    void (*vlog_detailed) (struct DB_plugin_s *plugin, uint32_t layer, const char *fmt, va_list ap);
+
     // High level easy-to-use log function, with no scope
     // These log messages cannot be disabled, and will always appear in the Log Viewers
     void (*log) (const char *fmt, ...);
+
+    // Same as log but uses va_list
+    void (*vlog) (const char *fmt, va_list ap);
 
     // Custom log viewers, for use in e.g. UI plugins
     void (*log_viewer_register) (void (*callback)(struct DB_plugin_s *plugin, uint32_t layers, const char *text));

--- a/logger.c
+++ b/logger.c
@@ -72,12 +72,32 @@ ddb_log_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, ...) {
 }
 
 void
+ddb_vlog_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, va_list ap) {
+    if (!_is_log_visible(plugin, layers)) {
+        return;
+    }
+
+    char text[2048];
+    (void) vsnprintf(text, sizeof (text), fmt, ap);
+
+    _log_internal (plugin, layers, text);
+}
+
+void
 ddb_log (const char *fmt, ...) {
     char text[2048];
     va_list ap;
     va_start(ap, fmt);
-    (void) vsnprintf(text, 128, fmt, ap);
+    (void) vsnprintf(text, sizeof (text), fmt, ap);
     va_end(ap);
+
+    _log_internal (NULL, 0, text);
+}
+
+void
+ddb_vlog (const char *fmt, va_list ap) {
+    char text[2048];
+    (void) vsnprintf(text, sizeof (text), fmt, ap);
 
     _log_internal (NULL, 0, text);
 }

--- a/logger.h
+++ b/logger.h
@@ -30,7 +30,13 @@ void
 ddb_log_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, ...);
 
 void
+ddb_vlog_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, va_list ap);
+
+void
 ddb_log (const char *fmt, ...);
+
+void
+ddb_vlog (const char *fmt, va_list ap);
 
 void
 ddb_log_viewer_register (void (*callback)(DB_plugin_t *plugin, uint32_t layers, const char *text));

--- a/plugins.c
+++ b/plugins.c
@@ -459,7 +459,9 @@ static DB_functions_t deadbeef_api = {
     .pl_meta_for_key = (DB_metaInfo_t * (*) (DB_playItem_t *it, const char *key))pl_meta_for_key,
 
     .log_detailed = ddb_log_detailed,
+    .vlog_detailed = ddb_vlog_detailed,
     .log = ddb_log,
+    .vlog = ddb_vlog,
 
     .log_viewer_register = ddb_log_viewer_register,
     .log_viewer_unregister = ddb_log_viewer_unregister,


### PR DESCRIPTION
This would allow more convenient integration with existing code that already uses variable arguments functions.

Compile checked on Linux, should I add some tests?

I've found this line in existing code suspicious a bit:

> (void) vsnprintf(text, 128, fmt, ap);

What is 128? Was it meant to be sizeof (text)?