### PR TITLE
gtkui: don't expand help link widget in group by dialog

### DIFF
--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -7415,7 +7415,7 @@ if you don't press Apply.</property>
 		    </widget>
 		    <packing>
 		      <property name="padding">0</property>
-		      <property name="expand">True</property>
+		      <property name="expand">False</property>
 		      <property name="fill">True</property>
 		    </packing>
 		  </child>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -3710,7 +3710,7 @@ create_groupbydlg (void)
 
   custom1 = title_formatting_help_link_create ("custom1", "", "", 0, 0);
   gtk_widget_show (custom1);
-  gtk_box_pack_start (GTK_BOX (hbox75), custom1, TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (hbox75), custom1, FALSE, TRUE, 0);
   gtk_widget_set_can_focus(custom1, FALSE);
   gtk_widget_set_can_default(custom1, FALSE);
 


### PR DESCRIPTION
Now when you resize the dialog all the extra space is added to the group by entry.