### PR TITLE
gtkui: don't expand help link widget in add/edit column dialog

### DIFF
--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2098,7 +2098,7 @@ Custom</property>
 		    </widget>
 		    <packing>
 		      <property name="padding">0</property>
-		      <property name="expand">True</property>
+		      <property name="expand">False</property>
 		      <property name="fill">True</property>
 		    </packing>
 		  </child>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1376,7 +1376,7 @@ create_editcolumndlg (void)
 
   title_formatting_help_link = title_formatting_help_link_create ("title_formatting_help_link", "", "", 0, 0);
   gtk_widget_show (title_formatting_help_link);
-  gtk_box_pack_start (GTK_BOX (hbox74), title_formatting_help_link, TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (hbox74), title_formatting_help_link, FALSE, TRUE, 0);
   gtk_widget_set_can_focus(title_formatting_help_link, FALSE);
   gtk_widget_set_can_default(title_formatting_help_link, FALSE);
 


### PR DESCRIPTION
Same patch as before, just for the add/edit column dialog.