### PR TITLE
add year to column dropdown options

### DIFF
--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -432,7 +432,7 @@ on_column_id_changed                   (GtkComboBox     *combobox,
         trace ("failed to get column format widget\n");
         return;
     }
-    gtk_widget_set_sensitive (fmt, act >= 10 ? TRUE : FALSE);
+    gtk_widget_set_sensitive (fmt, act >= 11 ? TRUE : FALSE);
 
     if (!editcolumn_title_changed) {
         GtkWidget *title= lookup_widget (toplevel, "title");

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2010,6 +2010,7 @@ Artist - Album
 Artist
 Album
 Title
+Year
 Duration
 Track Number
 Band / Album Artist

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1350,6 +1350,7 @@ create_editcolumndlg (void)
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Artist"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Album"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Title"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Year"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Duration"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Track Number"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Band / Album Artist"));

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1470,12 +1470,15 @@ init_column (col_info_t *inf, int id, const char *format) {
         inf->format = strdup (COLUMN_FORMAT_TITLE);
         break;
     case 7:
-        inf->format = strdup (COLUMN_FORMAT_LENGTH);
+        inf->format = strdup (COLUMN_FORMAT_YEAR);
         break;
     case 8:
-        inf->format = strdup (COLUMN_FORMAT_TRACKNUMBER);
+        inf->format = strdup (COLUMN_FORMAT_LENGTH);
         break;
     case 9:
+        inf->format = strdup (COLUMN_FORMAT_TRACKNUMBER);
+        break;
+    case 10:
         inf->format = strdup (COLUMN_FORMAT_BAND);
         break;
     default:

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -30,6 +30,7 @@
 #define COLUMN_FORMAT_ARTIST "$if(%artist%,%artist%,Unknown Artist)"
 #define COLUMN_FORMAT_ALBUM "%album%"
 #define COLUMN_FORMAT_TITLE "%title%"
+#define COLUMN_FORMAT_YEAR "%year%"
 #define COLUMN_FORMAT_LENGTH "%length%"
 #define COLUMN_FORMAT_TRACKNUMBER "%tracknumber%"
 #define COLUMN_FORMAT_BAND "$if(%album artist%,%album artist%,Unknown Artist)"


### PR DESCRIPTION
This adds the `year` as an option of the column drop down for when users wants to add additional columns.

When I first started looking into this, I was unsure how I could add the Year to a column as it wasn't under the pre-populated list -- I now know that I could have just entered `%year%`. Nonetheless, maybe some other users have been confused about this -- now one can simply select `year` from the drop down.

Thanks,
Alex