### PR TITLE
fix and enhance deadbeef.desktop.in

### DIFF
--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -14,7 +14,7 @@ Exec=deadbeef %F
 Terminal=false
 Actions=Play;Pause;Stop;Next;Prev
 MimeType=application/ogg;audio/x-vorbis+ogg;application/x-ogg;audio/mp3;audio/prs.sid;audio/x-flac;audio/mpeg;audio/x-mpeg;audio/x-mod;audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mpegurl;audio/x-scpls;
-Categories=AudioVideo;Player;GTK;
+Categories=Audio;AudioVideo;Player;GTK;
 Keywords=Sound;Music;Audio;Player;Musicplayer;MP3
 Keywords[zh_TW]=Sound;Music;Audio;Player;Musicplayer;MP3;音樂;音樂播放器;播放器;音訊
 

--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -16,6 +16,7 @@ Type=Application
 Icon=deadbeef
 X-PulseAudio-Properties=media.role=music
 
+Actions=Play;Pause;Stop;Next;Prev
 X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev
 
 Keywords=Sound;Music;Audio;Player;Musicplayer;MP3

--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Type=Application
 Name=DeaDBeeF
 GenericName=Audio Player
 GenericName[pt_BR]=Reprodutor de áudio
@@ -8,19 +9,17 @@ Comment=Listen to music
 Comment[pt_BR]=Escute músicas
 Comment[ru]=Слушай музыку
 Comment[zh_TW]=聆聽音樂
+Icon=deadbeef
 Exec=deadbeef %F
+Terminal=false
+Actions=Play;Pause;Stop;Next;Prev
 MimeType=application/ogg;audio/x-vorbis+ogg;application/x-ogg;audio/mp3;audio/prs.sid;audio/x-flac;audio/mpeg;audio/x-mpeg;audio/x-mod;audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mpegurl;audio/x-scpls;
 Categories=AudioVideo;Player;GTK;
-Terminal=false
-Type=Application
-Icon=deadbeef
-X-PulseAudio-Properties=media.role=music
-
-Actions=Play;Pause;Stop;Next;Prev
-X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev
-
 Keywords=Sound;Music;Audio;Player;Musicplayer;MP3
 Keywords[zh_TW]=Sound;Music;Audio;Player;Musicplayer;MP3;音樂;音樂播放器;播放器;音訊
+
+X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev
+X-PulseAudio-Properties=media.role=music
 
 [Play Shortcut Group]
 Name=Play

--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -71,7 +71,7 @@ Name=Next
 Name[zh_TW]=下一首
 Exec=deadbeef --next
 
-[Desktop Action Previous]
+[Desktop Action Prev]
 Name=Prev
 Name[zh_TW]=上一首
 Exec=deadbeef --prev


### PR DESCRIPTION
The issues were discovered by `desktop-file-validate` utility from the _desktop-file-utils_ package.

One issue still remains though:

```
deadbeef.desktop.in: error: file contains group "Play Shortcut Group", but groups extending the format should start with "X-"
deadbeef.desktop.in: error: file contains group "Pause Shortcut Group", but groups extending the format should start with "X-"
deadbeef.desktop.in: error: file contains group "Stop Shortcut Group", but groups extending the format should start with "X-"
deadbeef.desktop.in: error: file contains group "Next Shortcut Group", but groups extending the format should start with "X-"
deadbeef.desktop.in: error: file contains group "Prev Shortcut Group", but groups extending the format should start with "X-"
```

which is caused by https://bugs.launchpad.net/unity/+bug/789867. And according to https://bugs.launchpad.net/unity/+bug/789867/comments/4 this should be fixed in all non-EOL Ubuntu releases. But someone on Ubuntu should verify that dropping `X-Ayatana-Desktop-Shortcuts` key + all `[* Shortcut Group]` groups really doesn't affect UX.