### PR TITLE
blargg_endian: Fails to build on non-x86 with musl

### DIFF
--- a/plugins/gme/game-music-emu-0.6pre/gme/blargg_endian.h
+++ b/plugins/gme/game-music-emu-0.6pre/gme/blargg_endian.h
@@ -21,7 +21,7 @@
 // BLARGG_BIG_ENDIAN, BLARGG_LITTLE_ENDIAN: Determined automatically, otherwise only
 // one may be #defined to 1. Only needed if something actually depends on byte order.
 #if !defined (BLARGG_BIG_ENDIAN) && !defined (BLARGG_LITTLE_ENDIAN)
-#ifdef __GLIBC__
+#if defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && defined(__BIG_ENDIAN)
 	// GCC handles this for us
 	#include <endian.h>
 	#if __BYTE_ORDER == __LITTLE_ENDIAN


### PR DESCRIPTION
Currently blargg_endian fails to detect endiness on non-x86, as ppc64le,
when not using glibc.

In my case, I am using musl on ppc64le, and deadbeef fails to compile
because the endianess is not known.

This patch check if the macros are defined before using it, other than
checking for GLIBC.