### PR TITLE
Fixed compile warnings

### DIFF
--- a/tf.c
+++ b/tf.c
@@ -1820,7 +1820,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                             len = snprintf (out, outlen, "%.3lf KB", kb);
                         }
                         else {
-                            len = snprintf (out, outlen, "%lld B", bs);
+                            len = snprintf (out, outlen, "%ld B", bs);
                         }
                         out += len;
                         outlen -= len;
@@ -1933,7 +1933,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     }
                 }
                 else if (!strcmp (name, "length_samples")) {
-                    int len = snprintf (out, outlen, "%lld", pl_item_get_endsample ((playItem_t *)ctx->it) - pl_item_get_startsample ((playItem_t *)ctx->it));
+                    int len = snprintf (out, outlen, "%ld", pl_item_get_endsample ((playItem_t *)ctx->it) - pl_item_get_startsample ((playItem_t *)ctx->it));
                     out += len;
                     outlen -= len;
                     skip_out = 1;


### PR DESCRIPTION
>   CC       tf.o
> ../tf.c: In function ‘tf_eval_int’:
> ../tf.c:1823:58: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t {aka long int}’ [-Wformat=]
>                              len = snprintf (out, outlen, "%lld B", bs);
>                                                           ^
> ../tf.c:1823:58: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t {aka long int}’ [-Wformat=]
> ../tf.c:1936:54: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t {aka long int}’ [-Wformat=]
>                      int len = snprintf (out, outlen, "%lld", pl_item_get_endsample ((playItem_t *)ctx->it) - pl_item_get_startsample ((play
>                                                       ^
> ../tf.c:1936:54: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t {aka long int}’ [-Wformat=]