### PR TITLE
gtkui: fix vertical separator in preference dialog

### DIFF
--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -4956,8 +4956,8 @@ Only prevent clipping</property>
 			      <property name="visible">True</property>
 			    </widget>
 			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
+			      <property name="padding">5</property>
+			      <property name="expand">False</property>
 			      <property name="fill">True</property>
 			    </packing>
 			  </child>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -2466,7 +2466,7 @@ create_prefwin (void)
 
   vseparator1 = gtk_vseparator_new ();
   gtk_widget_show (vseparator1);
-  gtk_box_pack_start (GTK_BOX (listview_colors_group), vseparator1, TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (listview_colors_group), vseparator1, FALSE, TRUE, 5);
 
   frame13 = gtk_frame_new (NULL);
   gtk_widget_show (frame13);


### PR DESCRIPTION
The vertical separator was expanding leaving a huge gray area when resizing the preference dialog on GTK3.
