### PR TITLE
gtkui: add sort format to columns

### DIFF
--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2129,6 +2129,88 @@ Custom</property>
 	  </child>
 
 	  <child>
+	    <widget class="GtkHBox" id="hbox141">
+	      <property name="visible">True</property>
+	      <property name="homogeneous">False</property>
+	      <property name="spacing">8</property>
+
+	      <child>
+		<widget class="GtkLabel" id="label164">
+		  <property name="visible">True</property>
+		  <property name="label" translatable="yes">Sort format:</property>
+		  <property name="use_underline">False</property>
+		  <property name="use_markup">False</property>
+		  <property name="justify">GTK_JUSTIFY_LEFT</property>
+		  <property name="wrap">False</property>
+		  <property name="selectable">False</property>
+		  <property name="xalign">0.5</property>
+		  <property name="yalign">0.5</property>
+		  <property name="xpad">0</property>
+		  <property name="ypad">0</property>
+		  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+		  <property name="width_chars">-1</property>
+		  <property name="single_line_mode">False</property>
+		  <property name="angle">0</property>
+		</widget>
+		<packing>
+		  <property name="padding">0</property>
+		  <property name="expand">False</property>
+		  <property name="fill">False</property>
+		</packing>
+	      </child>
+
+	      <child>
+		<widget class="GtkEntry" id="sort_format">
+		  <property name="visible">True</property>
+		  <property name="can_focus">True</property>
+		  <property name="editable">True</property>
+		  <property name="visibility">True</property>
+		  <property name="max_length">0</property>
+		  <property name="text" translatable="yes"></property>
+		  <property name="has_frame">True</property>
+		  <property name="invisible_char">•</property>
+		  <property name="activates_default">False</property>
+		</widget>
+		<packing>
+		  <property name="padding">0</property>
+		  <property name="expand">True</property>
+		  <property name="fill">True</property>
+		</packing>
+	      </child>
+
+	      <child>
+		<widget class="GtkLabel" id="label165">
+		  <property name="visible">True</property>
+		  <property name="label" translatable="yes">(if non-empty)</property>
+		  <property name="use_underline">False</property>
+		  <property name="use_markup">False</property>
+		  <property name="justify">GTK_JUSTIFY_LEFT</property>
+		  <property name="wrap">False</property>
+		  <property name="selectable">False</property>
+		  <property name="xalign">0.5</property>
+		  <property name="yalign">0.5</property>
+		  <property name="xpad">0</property>
+		  <property name="ypad">0</property>
+		  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+		  <property name="width_chars">-1</property>
+		  <property name="single_line_mode">False</property>
+		  <property name="angle">0</property>
+		</widget>
+		<packing>
+		  <property name="padding">0</property>
+		  <property name="expand">False</property>
+		  <property name="fill">False</property>
+		</packing>
+	      </child>
+	    </widget>
+	    <packing>
+	      <property name="padding">0</property>
+	      <property name="expand">True</property>
+	      <property name="fill">True</property>
+	    </packing>
+	  </child>
+
+	  <child>
 	    <widget class="GtkHBox" id="hbox32">
 	      <property name="visible">True</property>
 	      <property name="homogeneous">False</property>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1292,6 +1292,10 @@ create_editcolumndlg (void)
   GtkWidget *hbox74;
   GtkWidget *format;
   GtkWidget *title_formatting_help_link;
+  GtkWidget *hbox141;
+  GtkWidget *label164;
+  GtkWidget *sort_format;
+  GtkWidget *label165;
   GtkWidget *hbox32;
   GtkWidget *label38;
   GtkWidget *align;
@@ -1390,6 +1394,23 @@ create_editcolumndlg (void)
   gtk_widget_set_can_focus(title_formatting_help_link, FALSE);
   gtk_widget_set_can_default(title_formatting_help_link, FALSE);
 
+  hbox141 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox141);
+  gtk_box_pack_start (GTK_BOX (vbox14), hbox141, TRUE, TRUE, 0);
+
+  label164 = gtk_label_new (_("Sort format:"));
+  gtk_widget_show (label164);
+  gtk_box_pack_start (GTK_BOX (hbox141), label164, FALSE, FALSE, 0);
+
+  sort_format = gtk_entry_new ();
+  gtk_widget_show (sort_format);
+  gtk_box_pack_start (GTK_BOX (hbox141), sort_format, TRUE, TRUE, 0);
+  gtk_entry_set_invisible_char (GTK_ENTRY (sort_format), 8226);
+
+  label165 = gtk_label_new (_("(if non-empty)"));
+  gtk_widget_show (label165);
+  gtk_box_pack_start (GTK_BOX (hbox141), label165, FALSE, FALSE, 0);
+
   hbox32 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox32);
   gtk_box_pack_start (GTK_BOX (vbox14), hbox32, FALSE, FALSE, 0);
@@ -1486,6 +1507,10 @@ create_editcolumndlg (void)
   GLADE_HOOKUP_OBJECT (editcolumndlg, hbox74, "hbox74");
   GLADE_HOOKUP_OBJECT (editcolumndlg, format, "format");
   GLADE_HOOKUP_OBJECT (editcolumndlg, title_formatting_help_link, "title_formatting_help_link");
+  GLADE_HOOKUP_OBJECT (editcolumndlg, hbox141, "hbox141");
+  GLADE_HOOKUP_OBJECT (editcolumndlg, label164, "label164");
+  GLADE_HOOKUP_OBJECT (editcolumndlg, sort_format, "sort_format");
+  GLADE_HOOKUP_OBJECT (editcolumndlg, label165, "label165");
   GLADE_HOOKUP_OBJECT (editcolumndlg, hbox32, "hbox32");
   GLADE_HOOKUP_OBJECT (editcolumndlg, label38, "label38");
   GLADE_HOOKUP_OBJECT (editcolumndlg, align, "align");

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -227,11 +227,11 @@ main_playlist_init (GtkWidget *widget) {
     deadbeef->conf_unlock ();
     // create default set of columns
     if (pl_common_load_column_config (listview, "gtkui.columns.playlist") < 0) {
-        pl_common_add_column_helper (listview, "♫", 50, DB_COLUMN_PLAYING, "%playstatus%", 0);
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, 0);
+        pl_common_add_column_helper (listview, "♫", 50, DB_COLUMN_PLAYING, "%playstatus%", NULL, 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, NULL, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, NULL, 0);
     }
     main_binding.columns_changed = main_columns_changed;
 }

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -60,7 +60,7 @@ int
 pl_common_load_column_config (DdbListview *listview, const char *key);
 
 void
-pl_common_add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, int align_right);
+pl_common_add_column_helper (DdbListview *listview, const char *title, int width, int id, const char *format, const char *sort_format, int align_right);
 
 void
 pl_common_header_context_menu (DdbListview *ps, int column);

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -647,10 +647,10 @@ search_playlist_init (GtkWidget *mainwin) {
     deadbeef->conf_unlock ();
     // create default set of columns
     if (pl_common_load_column_config (listview, "gtkui.columns.search") < 0) {
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, NULL, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, NULL, 0);
     }
     search_binding.columns_changed = search_columns_changed;
 


### PR DESCRIPTION
This adds a new text entry below Format in columns add/edit dialog. If non-empty it will be used for sorting instead of the display format.
