### PR TITLE
gtkui: refactor preset column types code

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -460,9 +460,11 @@ enum {
 // preset columns, working using IDs
 // DON'T add new ids in range 2-7, they are reserved for backwards compatibility
 enum pl_column_t {
+    DB_COLUMN_STANDARD = -1,
     DB_COLUMN_FILENUMBER = 0,
     DB_COLUMN_PLAYING = 1,
     DB_COLUMN_ALBUM_ART = 8,
+    DB_COLUMN_CUSTOM = 9
 };
 
 // replaygain constants

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -57,6 +57,7 @@
 #include "../hotkeys/hotkeys.h"
 #include "actionhandlers.h"
 #include "actions.h"
+#include "plcommon.h"
 
 //#define trace(...) { fprintf (stderr, __VA_ARGS__); }
 #define trace(fmt,...)
@@ -432,7 +433,7 @@ on_column_id_changed                   (GtkComboBox     *combobox,
         trace ("failed to get column format widget\n");
         return;
     }
-    gtk_widget_set_sensitive (fmt, act >= 11 ? TRUE : FALSE);
+    gtk_widget_set_sensitive (fmt, act == find_first_preset_column_type(DB_COLUMN_CUSTOM) ? TRUE : FALSE);
 
     if (!editcolumn_title_changed) {
         GtkWidget *title= lookup_widget (toplevel, "title");

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2013,18 +2013,7 @@
 	      <child>
 		<widget class="GtkComboBox" id="id">
 		  <property name="visible">True</property>
-		  <property name="items" translatable="yes">Item Index
-Playing
-Album Art
-Artist - Album
-Artist
-Album
-Title
-Year
-Duration
-Track Number
-Band / Album Artist
-Custom</property>
+		  <property name="items" translatable="yes"></property>
 		  <property name="add_tearoffs">False</property>
 		  <property name="focus_on_click">True</property>
 		  <signal name="changed" handler="on_column_id_changed" last_modification_time="Mon, 04 Jan 2010 17:31:44 GMT"/>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1356,18 +1356,6 @@ create_editcolumndlg (void)
   id = gtk_combo_box_text_new ();
   gtk_widget_show (id);
   gtk_box_pack_start (GTK_BOX (hbox30), id, TRUE, TRUE, 0);
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Item Index"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Playing"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Album Art"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Artist - Album"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Artist"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Album"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Title"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Year"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Duration"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Track Number"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Band / Album Artist"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (id), _("Custom"));
 
   hbox31 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox31);

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -228,10 +228,10 @@ main_playlist_init (GtkWidget *widget) {
     // create default set of columns
     if (pl_common_load_column_config (listview, "gtkui.columns.playlist") < 0) {
         pl_common_add_column_helper (listview, "♫", 50, DB_COLUMN_PLAYING, "%playstatus%", NULL, 0);
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, NULL, 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, NULL, 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, DB_COLUMN_STANDARD, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, DB_COLUMN_STANDARD, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, DB_COLUMN_STANDARD, COLUMN_FORMAT_TITLE, NULL, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, DB_COLUMN_STANDARD, COLUMN_FORMAT_LENGTH, NULL, 0);
     }
     main_binding.columns_changed = main_columns_changed;
 }

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -34,6 +34,8 @@
 #define COLUMN_FORMAT_LENGTH "%length%"
 #define COLUMN_FORMAT_TRACKNUMBER "%tracknumber%"
 #define COLUMN_FORMAT_BAND "$if(%album artist%,%album artist%,Unknown Artist)"
+#define COLUMN_FORMAT_CODEC "%codec%"
+#define COLUMN_FORMAT_BITRATE "%bitrate%"
 
 int
 pl_common_rewrite_column_config (DdbListview *listview, const char *name);
@@ -93,5 +95,8 @@ pl_common_set_group_format (DdbListview *listview, char *format_conf);
 // formatting to the new JSON syntax with new title formatting
 int
 import_column_config_0_6 (const char *oldkeyprefix, const char *newkey);
+
+int
+find_first_preset_column_type (int type);
 
 #endif // __PLCOLUMNS_H

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -647,10 +647,10 @@ search_playlist_init (GtkWidget *mainwin) {
     deadbeef->conf_unlock ();
     // create default set of columns
     if (pl_common_load_column_config (listview, "gtkui.columns.search") < 0) {
-        pl_common_add_column_helper (listview, _("Artist / Album"), 150, -1, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
-        pl_common_add_column_helper (listview, _("Track No"), 50, -1, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
-        pl_common_add_column_helper (listview, _("Title"), 150, -1, COLUMN_FORMAT_TITLE, NULL, 0);
-        pl_common_add_column_helper (listview, _("Duration"), 50, -1, COLUMN_FORMAT_LENGTH, NULL, 0);
+        pl_common_add_column_helper (listview, _("Artist / Album"), 150, DB_COLUMN_STANDARD, COLUMN_FORMAT_ARTISTALBUM, NULL, 0);
+        pl_common_add_column_helper (listview, _("Track No"), 50, DB_COLUMN_STANDARD, COLUMN_FORMAT_TRACKNUMBER, NULL, 1);
+        pl_common_add_column_helper (listview, _("Title"), 150, DB_COLUMN_STANDARD, COLUMN_FORMAT_TITLE, NULL, 0);
+        pl_common_add_column_helper (listview, _("Duration"), 50, DB_COLUMN_STANDARD, COLUMN_FORMAT_LENGTH, NULL, 0);
     }
     search_binding.columns_changed = search_columns_changed;
 


### PR DESCRIPTION
This makes adding/removing/rearranging the preset column types more manageable.
It also prepares the code if we want to make this user configurable in the future.
