### PR TITLE
gtkui: use GtkApplication model

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,8 +224,9 @@ AS_IF([test "${enable_gtk3}" = "yes"], [
         AC_SUBST(GTK3_DEPS_LIBS)
         HAVE_GTK3=yes
     ], [
-       PKG_CHECK_MODULES(GTK3_DEPS, gtk+-3.0 >= 3.0 gthread-2.0 glib-2.0, HAVE_GTK3=yes, HAVE_GTK3=no)
+       PKG_CHECK_MODULES(GTK3_DEPS, gtk+-3.0 >= 3.0 gthread-2.0 glib-2.0 gio-2.0, HAVE_GTK3=yes, HAVE_GTK3=no)
     ])
+    AC_PATH_PROG([GLIB_COMPILE_RESOURCES], [glib-compile-resources])
 dnl    AC_CHECK_LIB([SM], [main], [HAVE_SM=yes;SM_LIBS="-lSM";AC_SUBST(SM_LIBS)])
 dnl    AC_CHECK_LIB([ICE], [main], [HAVE_ICE=yes;ICE_LIBS="-lICE";AC_SUBST(ICE_LIBS)])
     if test "$OS_OSX" = "yes"; then

--- a/plugins/gtkui/Makefile.am
+++ b/plugins/gtkui/Makefile.am
@@ -80,7 +80,7 @@ ddb_gui_GTK2_la_CFLAGS = -std=c99 $(GTK2_DEPS_CFLAGS) $(SM_CFLAGS) $(JANSSON_CFL
 endif
 
 if HAVE_GTK3
-GTKUI_SOURCES_GTK3 = $(GTKUI_SOURCES)
+GTKUI_SOURCES_GTK3 = deadbeefapp.c deadbeefapp.h $(GTKUI_SOURCES)
 
 ddb_gui_GTK3_la_LDFLAGS = -module -avoid-version
 
@@ -88,6 +88,15 @@ ddb_gui_GTK3_la_SOURCES = $(GTKUI_SOURCES_GTK3)
 ddb_gui_GTK3_la_LIBADD = $(LDADD) $(GTK3_DEPS_LIBS) $(SM_LIBADD) ../libparser/libparser.a $(JANSSON_LIBS)
 ddb_gui_GTK3_la_CFLAGS = -std=c99 $(GTK3_DEPS_CFLAGS) $(SM_CFLAGS) $(JANSSON_CFLAGS)
 ddb_gui_GTK3_la_OBJCFLAGS = $(GTK3_DEPS_CFLAGS) $(SM_CFLAGS) $(JANSSON_CFLAGS)
+
+nodist_ddb_gui_GTK3_la_SOURCES = gtkui-gresources.c
+
+resource_files = \
+	gtkui.gresources.xml	\
+	gtk/menus.ui
+
+gtkui-gresources.c: $(resource_files)
+	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate-source $<
 
 endif
 

--- a/plugins/gtkui/deadbeefapp.c
+++ b/plugins/gtkui/deadbeefapp.c
@@ -1,0 +1,125 @@
+/*
+    DeaDBeeF -- the music player
+    GtkApplication implementation
+    Copyright (C) 2017 Nicolai Syvertsen
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+#include <gtk/gtk.h>
+#include "deadbeefapp.h"
+#include "gtkui.h"
+#include "support.h"
+
+struct _DeadbeefApp
+{
+    GtkApplication parent;
+
+    GSimpleAction *logaction;
+};
+
+G_DEFINE_TYPE(DeadbeefApp, deadbeef_app, GTK_TYPE_APPLICATION);
+
+DeadbeefApp *gapp;
+
+static void
+appmenu_quit_activated (GSimpleAction *action,
+                GVariant      *parameter,
+                gpointer       user_data)
+{
+    gtkui_quit ();
+}
+
+static void
+appmenu_preferences_activated (GSimpleAction *action,
+                GVariant      *parameter,
+                gpointer       user_data)
+{
+    gtkui_run_preferences_dlg ();
+}
+
+static void
+appmenu_log_change_state (GSimpleAction *action,
+                GVariant      *value,
+                gpointer       user_data)
+{
+    gboolean val = g_variant_get_boolean (value);
+    gtkui_show_log_window (val);
+}
+
+static void
+appmenu_about_activated (GSimpleAction *action,
+                GVariant      *parameter,
+                gpointer       user_data)
+{
+    GtkWidget *item = lookup_widget (mainwin, "about1");
+    gtk_menu_item_activate ( GTK_MENU_ITEM (item));
+}
+
+static GActionEntry app_entries[] = {
+    { "preferences", appmenu_preferences_activated, NULL, NULL, NULL },
+    { "log", NULL, NULL, "false", appmenu_log_change_state },
+    { "about", appmenu_about_activated, NULL, NULL, NULL },
+    { "quit", appmenu_quit_activated, NULL, NULL, NULL }
+};
+
+static void
+deadbeef_app_init (DeadbeefApp *app)
+{
+}
+
+static void
+deadbeef_app_activate (GApplication *application) {
+    gtkui_mainwin_init ();
+}
+
+static void
+deadbeef_app_startup (GApplication *application) {
+    G_APPLICATION_CLASS (deadbeef_app_parent_class)->startup (application);
+
+    g_action_map_add_action_entries (G_ACTION_MAP (application), app_entries, G_N_ELEMENTS (app_entries), application);
+    DEADBEEF_APP (application)->logaction = G_SIMPLE_ACTION (g_action_map_lookup_action ( G_ACTION_MAP (application), "log"));
+}
+
+GSimpleAction *
+deadbeef_app_get_log_action(DeadbeefApp *application) {
+    return application->logaction;
+}
+
+static void
+deadbeef_app_shutdown (GApplication *application) {
+    gtkui_mainwin_free ();
+    G_APPLICATION_CLASS (deadbeef_app_parent_class)->shutdown (application);
+}
+
+static void
+deadbeef_app_class_init (DeadbeefAppClass *class)
+{
+    G_APPLICATION_CLASS (class)->activate = deadbeef_app_activate;
+    G_APPLICATION_CLASS (class)->startup = deadbeef_app_startup;
+    G_APPLICATION_CLASS (class)->shutdown = deadbeef_app_shutdown;
+}
+
+DeadbeefApp *
+deadbeef_app_new (void)
+{
+    return g_object_new (DEADBEEF_APP_TYPE,
+                       "application-id", "music.deadbeef.player",
+                       "flags", G_APPLICATION_FLAGS_NONE,
+                       NULL);
+}

--- a/plugins/gtkui/deadbeefapp.h
+++ b/plugins/gtkui/deadbeefapp.h
@@ -1,0 +1,47 @@
+/*
+    DeaDBeeF -- the music player
+    GtkApplication implementation
+    Copyright (C) 2017 Nicolai Syvertsen
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef __GTKUI_DEADBEEFAPP_H
+#define __GTKUI_DEADBEEFAPP_H
+
+#include <gtk/gtk.h>
+
+#define DEADBEEF_APP_TYPE (deadbeef_app_get_type ())
+GType deadbeef_app_get_type (void);
+typedef struct _DeadbeefApp DeadbeefApp;
+typedef struct { GtkApplicationClass parent_class; } DeadbeefAppClass;
+
+static inline DeadbeefApp * DEADBEEF_APP(gpointer ptr) {
+    return G_TYPE_CHECK_INSTANCE_CAST (ptr, deadbeef_app_get_type (), DeadbeefApp);
+}
+// Only available since GLib 2.44:
+//G_DECLARE_FINAL_TYPE (DeadbeefApp, deadbeef_app, DEADBEEF, APP, GtkApplication)
+
+
+DeadbeefApp *
+deadbeef_app_new (void);
+
+GSimpleAction *
+deadbeef_app_get_log_action(DeadbeefApp *application);
+
+#endif /*__GTKUI_DEADBEEFAPP_H*/

--- a/plugins/gtkui/gtk/menus.ui
+++ b/plugins/gtkui/gtk/menus.ui
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<interface>
+  <menu id="app-menu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">_Preferences</attribute>
+        <attribute name="action">app.preferences</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Show log window</attribute>
+        <attribute name="action">app.log</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">_About DeaDBeeF</attribute>
+        <attribute name="action">app.about</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>

--- a/plugins/gtkui/gtkui.gresources.xml
+++ b/plugins/gtkui/gtkui.gresources.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<gresources>
+  <gresource prefix="/music/deadbeef/player">
+    <file preprocess="xml-stripblanks">gtk/menus.ui</file>
+  </gresource>
+</gresources>

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -32,6 +32,11 @@
 
 #include "../../deadbeef.h"
 
+#if GTK_CHECK_VERSION(3,0,0)
+#include "deadbeefapp.h"
+extern DeadbeefApp *gapp;
+#endif
+
 extern DB_functions_t *deadbeef;
 extern GtkWidget *mainwin;
 
@@ -172,5 +177,10 @@ gtkui_show_log_window(gboolean show);
 void
 gtkui_toggle_log_window(void);
 
+void
+gtkui_mainwin_init(void);
+
+void
+gtkui_mainwin_free(void);
 
 #endif

--- a/plugins/gtkui/progress.c
+++ b/plugins/gtkui/progress.c
@@ -96,6 +96,9 @@ gtkui_progress_show_idle (gpointer data) {
     gtk_widget_show_all (progressdlg);
     gtk_window_present (GTK_WINDOW (progressdlg));
     gtk_window_set_transient_for (GTK_WINDOW (progressdlg), GTK_WINDOW (mainwin));
+#if GTK_CHECK_VERSION(3,0,0)
+    g_application_mark_busy (G_APPLICATION (gapp));
+#endif
     return FALSE;
 }
 
@@ -108,6 +111,9 @@ progress_show (void) {
 gboolean
 gtkui_progress_hide_idle (gpointer data) {
     gtk_widget_hide (progressdlg);
+#if GTK_CHECK_VERSION(3,0,0)
+    g_application_unmark_busy (G_APPLICATION (gapp));
+#endif
     return FALSE;
 }
 

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,7 +8,7 @@ case "$TRAVIS_OS_NAME" in
         tar jxf ddb-static-deps.tar.bz2 -C static-deps || exit 1
         echo "installing the needed build dependencies..."
         sudo apt-get update 1> /dev/null 2> /dev/null || exit 1
-        sudo apt-get install -qq autopoint automake autoconf intltool libc6-dev-i386 libc6-dev yasm || exit 1
+        sudo apt-get install -qq autopoint automake autoconf intltool libc6-dev-i386 libc6-dev yasm libglib2.0-bin || exit 1
         echo "building for i686"
         ARCH=i686 ./scripts/static_build.sh || exit 1
         ARCH=i686 ./scripts/portable_package_static.sh || exit 1


### PR DESCRIPTION
This changes the GTK3 implementation to use a application class based on GtkApplication.
First primary benefit of this is to get access to appmenu functionality which is also implemented with this change.
Second is progress dialog now indicates to desktop shell that the app is busy. e.g Gnome-shell will display a spinner next to the application name in the top bar.

This also cleans up the GTK2 parts of the code. Calling gdk_threads_enter/leave is no longer necessary since DeaDBeeF now runs GTK+ in the main thread.
