### PR TITLE
pltbrowser: add option to disable double-click playlist switch

### DIFF
--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -996,7 +996,7 @@ pltbrowser_disconnect (void) {
 static const char pltbrowser_settings_dlg[] =
     "property \"Close playlists with middle mouse button\" checkbox gtkui.pltbrowser.mmb_delete_playlist 0;\n"
     "property \"Highlight current playlist\" checkbox gtkui.pltbrowser.highlight_curr_plt 0;\n"
-    "property \"Start playlist with double-click\" checkbox gtkui.pltbrowser.doubleclick_switch_playlist 1;\n"
+    "property \"Play on double-click\" checkbox gtkui.pltbrowser.play_on_double_click 1;\n"
 ;
 
 static DB_misc_t plugin = {

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -860,7 +860,7 @@ on_pltbrowser_popup_menu (GtkWidget *widget, gpointer user_data) {
 
 static void
 on_pltbrowser_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data) {
-    if (deadbeef->conf_get_int ("gtkui.pltbrowser.doubleclick_switch_playlist", 0))
+    if (deadbeef->conf_get_int ("gtkui.pltbrowser.doubleclick_switch_playlist", 1))
         deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, 0, 0);
 }
 

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -860,7 +860,8 @@ on_pltbrowser_popup_menu (GtkWidget *widget, gpointer user_data) {
 
 static void
 on_pltbrowser_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data) {
-    deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, 0, 0);
+    if (deadbeef->conf_get_int ("gtkui.pltbrowser.doubleclick_switch_playlist", 0))
+        deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, 0, 0);
 }
 
 static void
@@ -995,6 +996,7 @@ pltbrowser_disconnect (void) {
 static const char pltbrowser_settings_dlg[] =
     "property \"Close playlists with middle mouse button\" checkbox gtkui.pltbrowser.mmb_delete_playlist 0;\n"
     "property \"Highlight current playlist\" checkbox gtkui.pltbrowser.highlight_curr_plt 0;\n"
+    "property \"Start playlist with double-click\" checkbox gtkui.pltbrowser.doubleclick_switch_playlist 1;\n"
 ;
 
 static DB_misc_t plugin = {

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -860,7 +860,7 @@ on_pltbrowser_popup_menu (GtkWidget *widget, gpointer user_data) {
 
 static void
 on_pltbrowser_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data) {
-    if (deadbeef->conf_get_int ("gtkui.pltbrowser.doubleclick_switch_playlist", 1))
+    if (deadbeef->conf_get_int ("gtkui.pltbrowser.play_on_double_click", 1))
         deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, 0, 0);
 }
 


### PR DESCRIPTION
Allow users to disable changing playlist with doubleclick in playlist browser.