### PR TITLE
add cue playlist plugin (tracks/cdimage+cue support)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ DISTCLEANFILES = \
 deadbeef_SOURCES =\
 	main.c common.h deadbeef.h\
 	plugins.c plugins.h moduleconf.h\
-	playlist.c playlist.h \
+	shared/cueutil.c shared/cueutil.h playlist.c playlist.h \
 	plmeta.c pltmeta.c pltmeta.h\
 	streamer.c streamer.h\
 	dsp.c dsp.h\

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,7 @@ AC_ARG_ENABLE(staticlink, [AS_HELP_STRING([--enable-staticlink], [link everythin
 AC_ARG_ENABLE(portable, [AS_HELP_STRING([--enable-portable ], [make portable build (default: disabled, opts: yes,no,full)])], [enable_portable=$enableval], [enable_portable=no])
 AC_ARG_ENABLE(src,      [AS_HELP_STRING([--enable-src      ], [build libsamplerate (SRC) plugin (default: auto)])], [enable_src=$enableval], [enable_src=yes])
 AC_ARG_ENABLE(m3u,      [AS_HELP_STRING([--enable-m3u      ], [build m3u plugin (default: auto)])], [enable_m3u=$enableval], [enable_m3u=yes])
+AC_ARG_ENABLE(cue,      [AS_HELP_STRING([--enable-cue      ], [build cue plugin (default: auto)])], [enable_cue=$enableval], [enable_cue=yes])
 AC_ARG_ENABLE(vfs-zip,      [AS_HELP_STRING([--enable-vfs-zip      ], [build vfs_zip plugin (default: auto)])], [enable_vfs_zip=$enableval], [enable_vfs_zip=yes])
 AC_ARG_ENABLE(converter,      [AS_HELP_STRING([--enable-converter      ], [build converter plugin (default: auto)])], [enable_converter=$enableval], [enable_converter=yes])
 AC_ARG_ENABLE(artwork-imlib2, [AS_HELP_STRING([--enable-artwork-imlib2      ], [use imlib2 in artwork plugin (default: auto)])], [enable_artwork_imlib2=$enableval], [enable_artwork_imlib2=yes])
@@ -767,6 +768,10 @@ AS_IF([test "${enable_m3u}" != "no"], [
     HAVE_M3U=yes
 ])
 
+AS_IF([test "${enable_cue}" != "no"], [
+    HAVE_CUE=yes
+])
+
 AS_IF([test "${enable_vfs_zip}" != "no"], [
     AS_IF([test "${HAVE_ZLIB}" = "yes" -a "${HAVE_ZIP}" = "yes"], [
         HAVE_VFS_ZIP=yes
@@ -828,7 +833,7 @@ AS_IF([test "${enable_statusnotifier}" != "no"], [
     ])
 ])
 
-PLUGINS_DIRS="plugins/liboggedit plugins/libmp4ff plugins/libparser plugins/lastfm plugins/mp3 plugins/vorbis plugins/flac plugins/wavpack plugins/sndfile plugins/vfs_curl plugins/cdda plugins/gtkui plugins/alsa plugins/ffmpeg plugins/hotkeys plugins/oss plugins/artwork-legacy plugins/adplug plugins/ffap plugins/sid plugins/nullout plugins/supereq plugins/vtx plugins/gme plugins/pulse plugins/notify plugins/musepack plugins/wildmidi plugins/tta plugins/dca plugins/aac plugins/mms plugins/shellexec plugins/shellexecui plugins/dsp_libsrc plugins/m3u plugins/vfs_zip plugins/converter plugins/dumb plugins/shn plugins/psf plugins/mono2stereo plugins/alac plugins/wma plugins/pltbrowser plugins/coreaudio plugins/sc68 plugins/statusnotifier plugins/sndio"
+PLUGINS_DIRS="plugins/liboggedit plugins/libmp4ff plugins/libparser plugins/lastfm plugins/mp3 plugins/vorbis plugins/flac plugins/wavpack plugins/sndfile plugins/vfs_curl plugins/cdda plugins/gtkui plugins/alsa plugins/ffmpeg plugins/hotkeys plugins/oss plugins/artwork-legacy plugins/adplug plugins/ffap plugins/sid plugins/nullout plugins/supereq plugins/vtx plugins/gme plugins/pulse plugins/notify plugins/musepack plugins/wildmidi plugins/tta plugins/dca plugins/aac plugins/mms plugins/shellexec plugins/shellexecui plugins/dsp_libsrc plugins/m3u plugins/cue plugins/vfs_zip plugins/converter plugins/dumb plugins/shn plugins/psf plugins/mono2stereo plugins/alac plugins/wma plugins/pltbrowser plugins/coreaudio plugins/sc68 plugins/statusnotifier plugins/sndio"
 
 AM_CONDITIONAL(APE_USE_YASM, test "x$APE_USE_YASM" = "xyes")
 AM_CONDITIONAL(HAVE_VORBIS, test "x$HAVE_VORBISPLUGIN" = "xyes")
@@ -873,6 +878,7 @@ AM_CONDITIONAL(HAVE_AAC, test "x$HAVE_AAC" = "xyes")
 AM_CONDITIONAL(HAVE_MMS, test "x$HAVE_MMS" = "xyes")
 AM_CONDITIONAL(HAVE_DSP_SRC, test "x$HAVE_DSP_SRC" = "xyes")
 AM_CONDITIONAL(HAVE_M3U, test "x$HAVE_M3U" = "xyes")
+AM_CONDITIONAL(HAVE_CUE, test "x$HAVE_CUE" = "xyes")
 AM_CONDITIONAL(HAVE_VFS_ZIP, test "x$HAVE_VFS_ZIP" = "xyes")
 AM_CONDITIONAL(HAVE_CONVERTER, test "x$HAVE_CONVERTER" = "xyes")
 AM_CONDITIONAL(HAVE_IMLIB2, test "x$HAVE_IMLIB2" = "xyes")
@@ -938,6 +944,7 @@ plugins/aac/Makefile
 plugins/mms/Makefile
 plugins/dsp_libsrc/Makefile
 plugins/m3u/Makefile
+plugins/cue/Makefile
 plugins/vfs_zip/Makefile
 plugins/converter/Makefile
 plugins/dumb/Makefile
@@ -1020,6 +1027,7 @@ PRINT_PLUGIN_INFO([aac],[AAC player (m4a, aac, mp4) based on FAAD2],[test "x$HAV
 PRINT_PLUGIN_INFO([mms],[mms streaming support],[test "x$HAVE_MMS" = "xyes"])
 PRINT_PLUGIN_INFO([dsp_src],[High quality samplerate conversion using libsamplerate],[test "x$HAVE_DSP_SRC" = "xyes"])
 PRINT_PLUGIN_INFO([m3u],[M3U and PLS playlist support],[test "x$HAVE_M3U" = "xyes"])
+PRINT_PLUGIN_INFO([cue],[CUE playlist support],[test "x$HAVE_CUE" = "xyes"])
 PRINT_PLUGIN_INFO([vfs_zip],[zip archive support],[test "x$HAVE_VFS_ZIP" = "xyes"])
 PRINT_PLUGIN_INFO([converter],[plugin for converting files to any formats],[test "x$HAVE_CONVERTER" = "xyes"])
 dnl PRINT_PLUGIN_INFO([medialib],[media library support plugin],[test "x$HAVE_MEDIALIB" = "xyes"])

--- a/deadbeef.h
+++ b/deadbeef.h
@@ -1306,6 +1306,9 @@ typedef struct {
     // search results, or not
     void (*plt_search_process2) (ddb_playlist_t *plt, const char *text, int select_results);
 
+    void (*plt_set_cue_file) (const char *filename);
+    void (*plt_unset_cue_file) (void);
+
     // try loading external and embedded cuesheet, using the configured order (cue.prefer_embedded, default=0)
     DB_playItem_t * (*plt_process_cue) (ddb_playlist_t *plt, DB_playItem_t *after, DB_playItem_t *it, uint64_t numsamples, int samplerate);
 

--- a/deadbeef.h
+++ b/deadbeef.h
@@ -1306,9 +1306,6 @@ typedef struct {
     // search results, or not
     void (*plt_search_process2) (ddb_playlist_t *plt, const char *text, int select_results);
 
-    void (*plt_set_cue_file) (const char *filename);
-    void (*plt_unset_cue_file) (void);
-
     // try loading external and embedded cuesheet, using the configured order (cue.prefer_embedded, default=0)
     DB_playItem_t * (*plt_process_cue) (ddb_playlist_t *plt, DB_playItem_t *after, DB_playItem_t *it, uint64_t numsamples, int samplerate);
 
@@ -1415,6 +1412,8 @@ typedef struct {
 
     // get total playback time of selected tracks
     float (*plt_get_selection_playback_time) (ddb_playlist_t *plt);
+
+    void (*plt_set_cue_file) (ddb_playlist_t *plt, const char *filename);
 #endif
 } DB_functions_t;
 

--- a/playlist.c
+++ b/playlist.c
@@ -148,20 +148,6 @@ typedef struct ddb_fileadd_beginend_listener_s {
 
 static ddb_fileadd_beginend_listener_t *file_add_beginend_listeners;
 
-const char *cue_field_map[] = {
-    "CATALOG ", "CATALOG",
-    "ISRC ", "ISRC",
-    "REM DATE ", "year",
-    "REM GENRE ", "genre",
-    "REM COMMENT ", "comment",
-    "REM COMPOSER ", "composer",
-    "REM DISCNUMBER ", "disc",
-    "REM TOTALDISCS ", "numdiscs",
-    "REM DISCID ", "DISCID",
-    NULL, NULL,
-};
-#define MAX_EXTRA_TAGS_FROM_CUE ((sizeof(cue_field_map) / sizeof(cue_field_map[0])))
-
 void
 pl_set_order (int order) {
     int prev_order = pl_order;
@@ -382,7 +368,6 @@ plt_alloc (const char *title) {
     memset (plt, 0, sizeof (playlist_t));
     plt->refc = 1;
     plt->title = strdup (title);
-    plt->cue_file = NULL;
     return plt;
 }
 
@@ -831,47 +816,47 @@ pl_clear (void) {
 }
 
 static playItem_t *
-plt_process_cue_track (playlist_t *playlist, const char *fname, const int64_t startsample, playItem_t **prev, char *track, char *index00, char *index01, char *pregap, char *title, char *albumperformer, char *performer, char *albumsongwriter, char *songwriter, char *albumtitle, char *replaygain_album_gain, char *replaygain_album_peak, char *replaygain_track_gain, char *replaygain_track_peak, const char *decoder_id, const char *ftype, int samplerate) {
-    if (!track[0]) {
-        trace ("pl_process_cue_track: invalid track (file=%s, title=%s)\n", fname, title);
+plt_process_cue_track (playlist_t *playlist, const char *fname, const int64_t startsample, playItem_t **prev, const char *decoder_id, const char *ftype, int samplerate, char cuefields[CUE_MAX_FIELDS][255], char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255], int extra_tag_index) {
+    if (!cuefields[CUE_FIELD_TRACK][0]) {
+        trace ("pl_process_cue_track: invalid track (file=%s, title=%s)\n", fname, cuefields[CUE_FIELD_TITLE]);
         return NULL;
     }
-    if (!index00[0] && !index01[0]) {
-        trace ("pl_process_cue_track: invalid index (file=%s, title=%s, track=%s)\n", fname, title, track);
+    if (!cuefields[CUE_FIELD_INDEX00][0] && !cuefields[CUE_FIELD_INDEX01][0]) {
+        trace ("pl_process_cue_track: invalid index (file=%s, title=%s, track=%s)\n", fname, cuefields[CUE_FIELD_TITLE], cuefields[CUE_FIELD_TRACK]);
         return NULL;
     }
 #if SKIP_BLANK_CUE_TRACKS
     if (!title[0]) {
-        trace ("pl_process_cue_track: invalid title (file=%s, title=%s, track=%s)\n", fname, title, track);
+        trace ("pl_process_cue_track: invalid title (file=%s, title=%s, track=%s)\n", fname, cuefields[CUE_FIELD_TITLE], cuefields[CUE_FIELD_TRACK]);
         return NULL;
     }
 #endif
     // fix track number
-    char *p = track;
+    char *p = cuefields[CUE_FIELD_TRACK];
     while (*p && isdigit (*p)) {
         p++;
     }
     *p = 0;
     // check that indexes have valid timestamps
-    //float f_index00 = index00[0] ? pl_cue_parse_time (index00) : 0;
-    float f_index01 = index01[0] ? pl_cue_parse_time (index01) : 0;
-    float f_pregap = pregap[0] ? pl_cue_parse_time (pregap) : 0;
+    //float f_index00 = cuefields[CUE_FIELD_INDEX00][0] ? pl_cue_parse_time (cuefields[CUE_FIELD_INDEX00]) : 0;
+    float f_index01 = cuefields[CUE_FIELD_INDEX01][0] ? pl_cue_parse_time (cuefields[CUE_FIELD_INDEX01]) : 0;
+    float f_pregap = cuefields[CUE_FIELD_PREGAP][0] ? pl_cue_parse_time (cuefields[CUE_FIELD_PREGAP]) : 0;
     if (*prev) {
         float prevtime = 0;
-        if (pregap[0] && index01[0]) {
+        if (cuefields[CUE_FIELD_PREGAP][0] && cuefields[CUE_FIELD_INDEX01][0]) {
             // PREGAP command
             prevtime = f_index01 - f_pregap;
         }
-//        else if (index00[0] && index01[0]) {
+//        else if (cuefields[CUE_FIELD_INDEX00][0] && cuefields[CUE_FIELD_INDEX01][0]) {
 //            // pregap in index 00
-//            prevtime = f_index00;
+//            prevtime = f_cuefields[CUE_FIELD_INDEX00];
 //        }
-        else if (index01[0]) {
+        else if (cuefields[CUE_FIELD_INDEX01][0]) {
             // no pregap
             prevtime = f_index01;
         }
         else {
-            trace ("pl_process_cue_track: invalid pregap or index01 (pregap=%s, index01=%s)\n", pregap, index01);
+            trace ("pl_process_cue_track: invalid pregap or index01 (pregap=%s, index01=%s)\n", cuefields[CUE_FIELD_PREGAP], cuefields[CUE_FIELD_INDEX01]);
             return NULL;
         }
         pl_item_set_endsample (*prev, startsample + (prevtime * samplerate) - 1);
@@ -888,53 +873,20 @@ plt_process_cue_track (playlist_t *playlist, const char *fname, const int64_t st
 //        trace ("startsample=%d, endsample=%d, prevtime=%f, samplerate=%d, prev track duration=%f\n", pl_item_get_startsample (*prev), pl_item_get_endsample (*prev),  prevtime, samplerate, (*prev)->_duration);
     }
     // non-compliant hack to handle tracks which only store pregap info
-    if (!index01[0]) {
+    if (!cuefields[CUE_FIELD_INDEX01][0]) {
         *prev = NULL;
-        trace ("pl_process_cue_track: invalid index01 (pregap=%s, index01=%s)\n", pregap, index01);
+        trace ("pl_process_cue_track: invalid index01 (pregap=%s, index01=%s)\n", cuefields[CUE_FIELD_PREGAP], cuefields[CUE_FIELD_INDEX01]);
         return NULL;
     }
     playItem_t *it = pl_item_alloc_init (fname, decoder_id);
-    pl_set_meta_int (it, ":TRACKNUM", atoi (track));
-    pl_item_set_startsample (it, index01[0] ? startsample + f_index01 * samplerate : startsample);
+    pl_set_meta_int (it, ":TRACKNUM", atoi (cuefields[CUE_FIELD_TRACK]));
+    pl_item_set_startsample (it, cuefields[CUE_FIELD_INDEX01][0] ? startsample + f_index01 * samplerate : startsample);
     pl_item_set_endsample (it, -1); // will be filled by next read, or by decoder
     pl_replace_meta (it, ":FILETYPE", ftype);
-    if (performer[0]) {
-        pl_add_meta (it, "artist", performer);
-        if (albumperformer[0] && strcmp (albumperformer, performer)) {
-            pl_add_meta (it, "album artist", albumperformer);
-        }
-    }
-    else if (albumperformer[0]) {
-        pl_add_meta (it, "artist", albumperformer);
-    }
-    if (songwriter[0]) {
-        pl_add_meta (it, "SONGWRITER", songwriter);
-    }
-    else if (albumsongwriter[0]) {
-        pl_add_meta (it, "SONGWRITER", albumsongwriter);
-    }
-    if (albumtitle[0]) {
-        pl_add_meta (it, "album", albumtitle);
-    }
-    if (track[0]) {
-        pl_add_meta (it, "track", track);
-    }
-    if (title[0]) {
-        pl_add_meta (it, "title", title);
-    }
-    if (replaygain_album_gain[0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMGAIN, atof (replaygain_album_gain));
-    }
-    if (replaygain_album_peak[0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMPEAK, atof (replaygain_album_peak));
-    }
-    if (replaygain_track_gain[0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKGAIN, atof (replaygain_track_gain));
-    }
-    if (replaygain_track_peak[0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKPEAK, atof (replaygain_track_peak));
-    }
     it->_flags |= DDB_IS_SUBTRACK | DDB_TAG_CUESHEET;
+
+    pl_cue_set_track_field_values((ddb_playItem_t *)it, cuefields, extra_tags, extra_tag_index);
+
     *prev = it;
     return it;
 }
@@ -955,45 +907,27 @@ plt_insert_cue_from_buffer_int (playlist_t *playlist, playItem_t *after, playIte
     }
 
     // go through the file, and verify that it's not for multiple tracks
-    int fcount = 0;
     uint8_t *p = (uint8_t *)buffer;
-    uint8_t *e = (uint8_t *)(buffer + buffersize);
-    while (*p) {
-        while (*p <= 0x20 && *p) {
-            p++;
-        }
-        if (e-p > 4 && !memcmp ((char *)p, "FILE", 4) && p[4] == 0x20) {
-            fcount++;
-            if (fcount > 1) {
-                return NULL;
-            }
-        }
-        while (*p >= 0x20 && *p) {
-            p++;
-        }
+    uint8_t *end = (uint8_t *)(buffer + buffersize);
+    int ncuetracks, ncuefiles;
+    pl_cue_get_total_tracks_and_files(p, end, &ncuefiles, &ncuetracks);
+    if (ncuefiles > 1 || !ncuefiles || !ncuetracks) {
+        trace("Not loading cuesheet from buffer\n");
+        return NULL;
     }
 
     const char *charset = junk_detect_charset_len (buffer, buffersize);
 
     LOCK;
     playItem_t *ins = after;
-    char albumperformer[256] = "";
-    char performer[256] = "";
-    char albumsongwriter[256] = "" ;
-    char songwriter[256] = "" ;
-    char albumtitle[256] = "";
-    char track[256] = "";
-    char title[256] = "";
-    char pregap[256] = "";
-    char index00[256] = "";
-    char index01[256] = "";
-    char replaygain_album_gain[256] = "";
-    char replaygain_album_peak[256] = "";
-    char replaygain_track_gain[256] = "";
-    char replaygain_track_peak[256] = "";
+
     const char *uri = pl_find_meta_raw (origin, ":URI");
     const char *dec = pl_find_meta_raw (origin, ":DECODER");
     const char *filetype = pl_find_meta_raw (origin, ":FILETYPE");
+
+    char cuefields[CUE_MAX_FIELDS][255];
+    memset(cuefields, 0, sizeof(cuefields));
+    snprintf(cuefields[CUE_FIELD_TOTALTRACKS], sizeof(cuefields[CUE_FIELD_TOTALTRACKS]), "%d", ncuetracks);
 
     char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255];
     memset (extra_tags, 0, sizeof (extra_tags));
@@ -1002,7 +936,7 @@ plt_insert_cue_from_buffer_int (playlist_t *playlist, playItem_t *after, playIte
     int have_track = 0;
 
     playItem_t *cuetracks[MAX_CUE_TRACKS];
-    int ncuetracks = 0;
+    ncuetracks = 0;
 
     playItem_t *prev = NULL;
     while (buffersize > 0) {
@@ -1027,34 +961,12 @@ plt_insert_cue_from_buffer_int (playlist_t *playlist, playItem_t *after, playIte
         buffer = p;
         p = pl_cue_skipspaces (str);
 
-        if (!strncasecmp (p, "PERFORMER ", 10)) {
-            if (!track[0]) {
-                pl_get_qvalue_from_cue (p + 10, sizeof (albumperformer), albumperformer, charset);
-            }
-            else {
-                pl_get_qvalue_from_cue (p + 10, sizeof (performer), performer, charset);
-            }
-        }
-        else if (!strncasecmp (p, "SONGWRITER ", 11)) {
-            if (!track[0]) {
-                pl_get_qvalue_from_cue (p + 11, sizeof (albumsongwriter), albumsongwriter, charset);
-            }
-            else {
-                pl_get_qvalue_from_cue (p + 11, sizeof (songwriter), songwriter, charset);
-            }
-        }
-        else if (!strncasecmp (p, "TITLE ", 6)) {
-            if (str[0] > ' ' && !albumtitle[0]) {
-                pl_get_qvalue_from_cue (p + 6, sizeof (albumtitle), albumtitle, charset);
-            }
-            else {
-                pl_get_qvalue_from_cue (p + 6, sizeof (title), title, charset);
-            }
-        }
-        else if (!strncasecmp (p, "TRACK ", 6)) {
+        int field = pl_cue_get_field_value(p, cuefields, extra_tags, charset, have_track, &extra_tag_index);
+
+        if (field == CUE_FIELD_TRACK) {
             if (have_track) {
                 // add previous track
-                playItem_t *it = plt_process_cue_track (playlist, uri, pl_item_get_startsample (origin), &prev, track, index00, index01, pregap, title, albumperformer, performer, albumsongwriter, songwriter, albumtitle, replaygain_album_gain, replaygain_album_peak, replaygain_track_gain, replaygain_track_peak, dec, filetype, samplerate);
+                playItem_t *it = plt_process_cue_track (playlist, uri, pl_item_get_startsample (origin), &prev, dec, filetype, samplerate, cuefields, extra_tags, extra_tag_index);
                 if (it) {
                     if ((pl_item_get_startsample (it)-pl_item_get_startsample (origin)) >= numsamples || (pl_item_get_endsample (it)-pl_item_get_startsample (origin)) >= numsamples) {
                         goto error;
@@ -1062,59 +974,16 @@ plt_insert_cue_from_buffer_int (playlist_t *playlist, playItem_t *after, playIte
                     cuetracks[ncuetracks++] = it;
                 }
             }
-
+            pl_cue_reset_per_track_fields(cuefields);
+            pl_get_value_from_cue (p + 6, sizeof (cuefields[CUE_FIELD_TRACK]), cuefields[CUE_FIELD_TRACK]);
             have_track = 1;
-            track[0] = 0;
-            title[0] = 0;
-            pregap[0] = 0;
-            index00[0] = 0;
-            index01[0] = 0;
-            replaygain_track_gain[0] = 0;
-            replaygain_track_peak[0] = 0;
-            performer[0] = 0;
-            songwriter[0] = 0;
-            pl_get_value_from_cue (p + 6, sizeof (track), track);
         }
-        else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_GAIN ", 26)) {
-            pl_get_value_from_cue (p + 26, sizeof (replaygain_album_gain), replaygain_album_gain);
-        }
-        else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_PEAK ", 26)) {
-            pl_get_value_from_cue (p + 26, sizeof (replaygain_album_peak), replaygain_album_peak);
-        }
-        else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_GAIN ", 26)) {
-            pl_get_value_from_cue (p + 26, sizeof (replaygain_track_gain), replaygain_track_gain);
-        }
-        else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_PEAK ", 26)) {
-            pl_get_value_from_cue (p + 26, sizeof (replaygain_track_peak), replaygain_track_peak);
-        }
-        else if (!strncasecmp (p, "PREGAP ", 7)) {
-            pl_get_value_from_cue (p + 7, sizeof (pregap), pregap);
-        }
-        else if (!strncasecmp (p, "INDEX 00 ", 9)) {
-            pl_get_value_from_cue (p + 9, sizeof (index00), index00);
-        }
-        else if (!strncasecmp (p, "INDEX 01 ", 9)) {
-            pl_get_value_from_cue (p + 9, sizeof (index01), index01);
-        }
-        else {
-            // determine and get extra tags
-            if (!have_track) {
-                for (int m = 0; cue_field_map[m]; m += 2) {
-                    if (!strncasecmp (p, cue_field_map[m], strlen(cue_field_map[m]))) {
-                        strcpy(extra_tags[extra_tag_index],cue_field_map[m+1]);
-                        pl_get_qvalue_from_cue (p + strlen(cue_field_map[m]), sizeof(extra_tags[extra_tag_index+1]), extra_tags[extra_tag_index+1], charset);
-                        extra_tag_index += 2;
-                        continue;
-                    }
-                }
-            }
-//          fprintf (stderr, "got unknown line:\n%s\n", p);
-        }
+
     } /* end of while loop */
 
     if (have_track) {
         // handle last track
-        playItem_t *it = plt_process_cue_track (playlist, uri, pl_item_get_startsample (origin), &prev, track, index00, index01, pregap, title, albumperformer, performer, albumsongwriter, songwriter, albumtitle, replaygain_album_gain, replaygain_album_peak, replaygain_track_gain, replaygain_track_peak, dec, filetype, samplerate);
+        playItem_t *it = plt_process_cue_track (playlist, uri, pl_item_get_startsample (origin), &prev, dec, filetype, samplerate, cuefields, extra_tags, extra_tag_index);
         if (it) {
             pl_item_set_endsample (it, pl_item_get_startsample (origin) + numsamples - 1);
             if ((pl_item_get_endsample (it)-pl_item_get_startsample (origin)) >= numsamples || (pl_item_get_startsample (it)-pl_item_get_startsample (origin)) >= numsamples) {
@@ -1125,26 +994,10 @@ plt_insert_cue_from_buffer_int (playlist_t *playlist, playItem_t *after, playIte
         }
     }
 
-    if (!ncuetracks) {
-        UNLOCK;
-        return NULL;
-    }
-
-    char totaltracks[10];
-    snprintf(totaltracks, sizeof(totaltracks), "%d", ncuetracks);
-
     playItem_t *last = cuetracks[ncuetracks-1];
     pl_item_ref (last);
 
     for (int i = 0; i < ncuetracks; i++) {
-        // add extra tags to tracks
-        for (int y = 0; y < extra_tag_index; y += 2) {
-            if (extra_tags[y+1]) {
-                pl_add_meta (cuetracks[i], extra_tags[y], extra_tags[y+1]);
-            }
-        }
-        // generated "total tracks" field
-        pl_add_meta(cuetracks[i], "numtracks", totaltracks);
         after = plt_insert_item (playlist, after, cuetracks[i]);
         pl_item_unref (cuetracks[i]);
     }

--- a/playlist.h
+++ b/playlist.h
@@ -553,6 +553,12 @@ playItem_t *
 plt_process_cue (playlist_t *plt, playItem_t *after, playItem_t *it, uint64_t totalsamples, int samplerate);
 
 void
+plt_set_cue_file(const char *filename);
+
+void
+plt_unset_cue_file(void);
+
+void
 pl_configchanged (void);
 
 DB_metaInfo_t *

--- a/playlist.h
+++ b/playlist.h
@@ -63,6 +63,7 @@ typedef struct playItem_s {
 
 typedef struct playlist_s {
     char *title;
+    char *cue_file;
     struct playlist_s *next;
     int count[2];
     float totaltime;
@@ -79,7 +80,6 @@ typedef struct playlist_s {
     unsigned fast_mode : 1;
     unsigned files_adding : 1;
     unsigned recalc_seltime : 1;
-    char *cue_file;
 } playlist_t;
 
 // global playlist control functions

--- a/playlist.h
+++ b/playlist.h
@@ -79,6 +79,7 @@ typedef struct playlist_s {
     unsigned fast_mode : 1;
     unsigned files_adding : 1;
     unsigned recalc_seltime : 1;
+    char *cue_file;
 } playlist_t;
 
 // global playlist control functions
@@ -553,10 +554,7 @@ playItem_t *
 plt_process_cue (playlist_t *plt, playItem_t *after, playItem_t *it, uint64_t totalsamples, int samplerate);
 
 void
-plt_set_cue_file(const char *filename);
-
-void
-plt_unset_cue_file(void);
+plt_set_cue_file(playlist_t *plt, const char *filename);
 
 void
 pl_configchanged (void);

--- a/plugins.c
+++ b/plugins.c
@@ -460,6 +460,8 @@ static DB_functions_t deadbeef_api = {
 
     .plt_search_process2 = (void (*) (ddb_playlist_t *plt, const char *text, int select_results))plt_search_process2,
     .plt_process_cue = (DB_playItem_t * (*) (ddb_playlist_t *plt, DB_playItem_t *after, DB_playItem_t *it, uint64_t numsamples, int samplerate))plt_process_cue,
+    .plt_set_cue_file = (void (*) (const char *filename))plt_set_cue_file,
+    .plt_unset_cue_file = (void (*) (void))plt_unset_cue_file,
     .pl_meta_for_key = (DB_metaInfo_t * (*) (DB_playItem_t *it, const char *key))pl_meta_for_key,
 
     .log_detailed = ddb_log_detailed,

--- a/plugins.c
+++ b/plugins.c
@@ -460,8 +460,6 @@ static DB_functions_t deadbeef_api = {
 
     .plt_search_process2 = (void (*) (ddb_playlist_t *plt, const char *text, int select_results))plt_search_process2,
     .plt_process_cue = (DB_playItem_t * (*) (ddb_playlist_t *plt, DB_playItem_t *after, DB_playItem_t *it, uint64_t numsamples, int samplerate))plt_process_cue,
-    .plt_set_cue_file = (void (*) (const char *filename))plt_set_cue_file,
-    .plt_unset_cue_file = (void (*) (void))plt_unset_cue_file,
     .pl_meta_for_key = (DB_metaInfo_t * (*) (DB_playItem_t *it, const char *key))pl_meta_for_key,
 
     .log_detailed = ddb_log_detailed,
@@ -494,6 +492,8 @@ static DB_functions_t deadbeef_api = {
     .pl_item_set_endsample = (void (*) (DB_playItem_t *it, int64_t sample))pl_item_set_endsample,
 
     .plt_get_selection_playback_time = (float (*) (ddb_playlist_t *plt))plt_get_selection_playback_time,
+
+    .plt_set_cue_file = (void (*) (ddb_playlist_t *plt, const char *filename))plt_set_cue_file,
 };
 
 DB_functions_t *deadbeef = &deadbeef_api;

--- a/plugins/cue/COPYING
+++ b/plugins/cue/COPYING
@@ -1,0 +1,21 @@
+CUE playlist plugin for DeaDBeeF Player
+Copyright (C) 2017 Alexey Yakovenko
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+ claim that you wrote the original software. If you use this software
+ in a product, an acknowledgment in the product documentation would be
+ appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+ misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+

--- a/plugins/cue/COPYING
+++ b/plugins/cue/COPYING
@@ -1,5 +1,5 @@
 CUE playlist plugin for DeaDBeeF Player
-Copyright (C) 2017 wdlkmpx
+Copyright (C) 2017 github:wdlkmpx
 Copyright (C) 2017 Alexey Yakovenko
 
 This software is provided 'as-is', without any express or implied

--- a/plugins/cue/COPYING
+++ b/plugins/cue/COPYING
@@ -1,4 +1,5 @@
 CUE playlist plugin for DeaDBeeF Player
+Copyright (C) 2017 wdlkmpx
 Copyright (C) 2017 Alexey Yakovenko
 
 This software is provided 'as-is', without any express or implied

--- a/plugins/cue/Makefile.am
+++ b/plugins/cue/Makefile.am
@@ -1,7 +1,7 @@
 if HAVE_CUE
 pkglib_LTLIBRARIES = cue.la
 
-cue_la_SOURCES = cue.c
+cue_la_SOURCES = cue.c ../../shared/cueutil.c ../../shared/cueutil.h
 
 cue_la_LDFLAGS = -module -avoid-version -lm
 

--- a/plugins/cue/Makefile.am
+++ b/plugins/cue/Makefile.am
@@ -1,0 +1,11 @@
+if HAVE_CUE
+pkglib_LTLIBRARIES = cue.la
+
+cue_la_SOURCES = cue.c
+
+cue_la_LDFLAGS = -module -avoid-version -lm
+
+cue_la_LIBADD = $(LIBADD)
+
+cue_la_CFLAGS = $(CFLAGS) -std=c99
+endif

--- a/plugins/cue/cue.c
+++ b/plugins/cue/cue.c
@@ -1,0 +1,616 @@
+/*
+    CUE playlist plugin for DeaDBeeF Player
+    Copyright (C) 2017 Alexey Yakovenko
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifdef HAVE_CONFIG_H
+#  include "../../config.h"
+#endif
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "../../deadbeef.h"
+
+//#define trace(...) { fprintf(stderr, __VA_ARGS__); }
+#define trace(fmt,...)
+
+static DB_functions_t *deadbeef;
+
+//===================================================================================
+
+#define SKIP_BLANK_CUE_TRACKS 0
+
+const char *cue_field_map[] = {
+    "CATALOG ", "CATALOG",
+    "ISRC ", "ISRC",
+    "REM DATE ", "year",
+    "REM GENRE ", "genre",
+    "REM COMMENT ", "comment",
+    "REM COMPOSER ", "composer",
+    "REM DISCNUMBER ", "disc",
+    "REM TOTALDISCS ", "numdiscs",
+    "REM DISCID ", "DISCID",
+    NULL, NULL,
+};
+#define MAX_EXTRA_TAGS_FROM_CUE ((sizeof(cue_field_map) / sizeof(cue_field_map[0])))
+static int extra_tag_index = 0;
+
+static const uint8_t *
+pl_cue_skipspaces (const uint8_t *p) {
+    while (*p && *p <= ' ') {
+        p++;
+    }
+    return p;
+}
+
+static void
+pl_get_qvalue_from_cue (const uint8_t *p, int sz, char *out, const char *charset) {
+    char *str = out;
+    if (*p == 0) {
+        *out = 0;
+        return;
+    }
+    p = pl_cue_skipspaces (p);
+    if (*p == 0) {
+        *out = 0;
+        return;
+    }
+
+    if (*p == '"') {
+        p++;
+        p = pl_cue_skipspaces (p);
+        while (*p && *p != '"' && sz > 1) {
+            sz--;
+            *out++ = *p++;
+        }
+        *out = 0;
+    }
+    else {
+        while (*p && *p >= 0x20) {
+            sz--;
+            *out++ = *p++;
+        }
+        out--;
+        while (out > str && *out == 0x20) {
+            out--;
+        }
+        out++;
+        *out = 0;
+    }
+
+    if (!charset) {
+        return;
+    }
+
+    // recode
+    size_t l = strlen (str);
+    if (l == 0) {
+        return;
+    }
+
+    char recbuf[l*10];
+    int res = deadbeef->junk_recode (str, (int)l, recbuf, (int)(sizeof (recbuf)-1), charset);
+    if (res >= 0) {
+        strcpy (str, recbuf);
+    }
+    else
+    {
+        strcpy (str, "<UNRECOGNIZED CHARSET>");
+    }
+}
+
+static void
+pl_get_value_from_cue (const char *p, int sz, char *out) {
+    while (*p >= ' ' && sz > 1) {
+        sz--;
+        *out++ = *p++;
+    }
+    while (out > p && (*(out-1) == 0x20 || *(out-1) == 0x8)) {
+        out--;
+    }
+    *out = 0;
+}
+
+void
+plt_process_cue_track2 (DB_playItem_t *it, const char *fname, char *track, char *index00, char *index01, char *pregap, char *title, char *albumperformer, char *performer, char *albumsongwriter, char *songwriter, char *albumtitle, char *replaygain_album_gain, char *replaygain_album_peak, char *replaygain_track_gain, char *replaygain_track_peak, char *totaltracks, char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255]) {
+	DB_playItem_t *prev = it;
+    if (!track[0]) {
+        trace ("pl_process_cue_track: invalid track (file=%s, title=%s)\n", fname, title);
+        return;
+    }
+    if (!index00[0] && !index01[0]) {
+        trace ("pl_process_cue_track: invalid index (file=%s, title=%s, track=%s)\n", fname, title, track);
+        //return;
+    }
+#if SKIP_BLANK_CUE_TRACKS
+    if (!title[0]) {
+        trace ("pl_process_cue_track: invalid title (file=%s, title=%s, track=%s)\n", fname, title, track);
+        return;
+    }
+#endif
+    // fix track number
+    char *p = track;
+    while (*p && isdigit (*p)) {
+        p++;
+    }
+    *p = 0;
+
+    if (!index01[0]) {
+        trace ("pl_process_cue_track: invalid index01 (pregap=%s, index01=%s)\n", pregap, index01);
+    }
+
+    if (performer[0]) {
+        deadbeef->pl_add_meta (it, "artist", performer);
+        if (albumperformer[0] && strcmp (albumperformer, performer)) {
+            deadbeef->pl_add_meta (it, "album artist", albumperformer);
+        }
+    }
+    else if (albumperformer[0]) {
+        deadbeef->pl_add_meta (it, "artist", albumperformer);
+    }
+    if (songwriter[0]) {
+        deadbeef->pl_add_meta (it, "SONGWRITER", songwriter);
+    }
+    else if (albumsongwriter[0]) {
+        deadbeef->pl_add_meta (it, "SONGWRITER", albumsongwriter);
+    }
+    if (albumtitle[0]) {
+        deadbeef->pl_add_meta (it, "album", albumtitle);
+    }
+    if (track[0]) {
+        deadbeef->pl_add_meta (it, "track", track);
+    }
+    if (title[0]) {
+        deadbeef->pl_add_meta (it, "title", title);
+    }
+    if (replaygain_album_gain[0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMGAIN, atof (replaygain_album_gain));
+    }
+    if (replaygain_album_peak[0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMPEAK, atof (replaygain_album_peak));
+    }
+    if (replaygain_track_gain[0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKGAIN, atof (replaygain_track_gain));
+    }
+    if (replaygain_track_peak[0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKPEAK, atof (replaygain_track_peak));
+    }
+
+    uint32_t iflags = deadbeef->pl_get_item_flags(it);
+    iflags |= DDB_TAG_CUESHEET;
+    deadbeef->pl_set_item_flags(it, iflags);
+
+    // add extra tags to tracks
+    for (int y = 0; y < extra_tag_index; y += 2) {
+        if (extra_tags[y+1]) {
+            deadbeef->pl_add_meta (it, extra_tags[y], extra_tags[y+1]);
+        }
+    }
+    // generated "total tracks" field
+    deadbeef->pl_add_meta(it, "numtracks", totaltracks);
+
+}
+
+//=====================================================================================
+
+static const uint8_t *
+skipspaces (const uint8_t *p, const uint8_t *end) {
+    while (p < end && *p <= ' ') {
+        p++;
+    }
+    return p;
+}
+
+static DB_playItem_t *
+load_cue (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname, int *pabort, int (*cb)(DB_playItem_t *it, void *data), void *user_data) {
+    const char *slash = strrchr (fname, '/');
+    char cue_file_dir[strlen(fname) + 10];
+    memset(cue_file_dir, 0, sizeof(cue_file_dir));
+    if (slash && slash > fname) {
+        strncpy(cue_file_dir, fname, slash - fname);
+    }
+    trace ("enter pl_insert_cue: fname \n");
+    trace ("cue directory: %s \n", cue_file_dir);
+    // skip all empty lines and comments
+    DB_FILE *fp = deadbeef->fopen (fname);
+    if (!fp) {
+        trace ("failed to open file %s\n", fname);
+        return NULL;
+    }
+
+    int sz = deadbeef->fgetlength (fp);
+    trace ("loading cue...\n");
+    uint8_t *membuffer = malloc (sz);
+    if (!membuffer) {
+        deadbeef->fclose (fp);
+        trace ("failed to allocate %d bytes to read the file %s\n", sz, fname);
+        free (membuffer);
+        return NULL;
+    }
+    uint8_t *buffer = membuffer;
+    deadbeef->fread (buffer, 1, sz, fp);
+    deadbeef->fclose (fp);
+
+    if (sz >= 3 && buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf) {
+        buffer += 3;
+        sz -= 3;
+    }
+
+    const char *charset = deadbeef->junk_detect_charset (buffer);
+
+    const uint8_t *p = buffer;
+    const uint8_t *end = buffer+sz;
+
+    // determine total tracks/files
+    int ncuetracks = 0;
+    int ncuefiles = 0;
+    while (p < end) {
+        p = skipspaces (p, end);
+        if (p >= end) {
+            break;
+        }
+        if (!strncasecmp (p, "FILE ", 5)) {
+            ncuefiles++;
+        }
+        if (!strncasecmp (p, "TRACK ", 6)) {
+            ncuetracks++;
+        }
+        // move pointer to the next line
+        while (p < end && *p >= 0x20) {
+           p++;
+        }
+    }
+    trace("totaltracks: %d\n", ncuetracks);
+    trace("totalfiles: %d\n", ncuefiles);
+    if (!ncuefiles || !ncuetracks) {
+        deadbeef->log("invalid cuesheet (%s)\n", fname);
+        return NULL;
+    }
+
+    if (ncuefiles == 1) {
+        deadbeef->pl_lock();
+        // Only 1 file, get the filename 
+        // - set the internal deadbeef cue_file variable
+        // - insert audio_file to playlist
+        // - expect decoders to call deadbeef->plt_insert_cue_int(...), or plt_process_cue
+        // - unset cue_file
+        char audio_file[255] = "";
+        p = buffer;
+        while (p < end) {
+            p = skipspaces (p, end);
+            if (p >= end) {
+                break;
+            }
+            if (!strncasecmp (p, "FILE ", 5)) {
+                DB_playItem_t *it = NULL;
+                pl_get_qvalue_from_cue (p + 5, sizeof (audio_file), audio_file, charset);
+                deadbeef->plt_set_cue_file(fname);
+                if (audio_file[0] == '/') { //full path
+                    trace ("pl_insert_cue: adding file %s\n", audio_file);
+                    it = deadbeef->plt_insert_file2 (0, plt, after, audio_file, pabort, cb, user_data);
+                }
+                else {
+                    int l = strlen(cue_file_dir) + strlen (audio_file) + 10;
+                    char fullpath[l];
+                    trace ("pl_insert_cue: adding file %s\n", fullpath);
+                    snprintf(fullpath, sizeof(fullpath), "%s/%s", cue_file_dir, audio_file);
+                    it = deadbeef->plt_insert_file2 (0, plt, after, fullpath, pabort, cb, user_data);
+                }
+                deadbeef->plt_unset_cue_file();
+                free(membuffer);
+                deadbeef->pl_unlock();
+                return it;
+            }
+            // move pointer to the next line
+            while (p < end && *p >= 0x20) {
+               p++;
+            }
+        }
+        free(membuffer);
+        deadbeef->pl_unlock();
+        return NULL;
+    } /* end of (ncuefiles == 1) */
+
+    if (ncuefiles > 1 && ncuefiles != ncuetracks) {
+        deadbeef->log("%s: the number of TRACKS must be equal to the number of FILES..\n", fname);
+        return NULL;
+    }
+
+    char totaltracks[10];
+    snprintf(totaltracks, sizeof(totaltracks), "%d", ncuetracks);
+
+    char file[256] = "";
+    char albumperformer[256] = "";
+    char performer[256] = "";
+    char albumsongwriter[256] = "" ;
+    char songwriter[256] = "" ;
+    char albumtitle[256] = "";
+    char track[256] = "";
+    char title[256] = "";
+    char pregap[256] = "";
+    char index00[256] = "";
+    char index01[256] = "";
+    char replaygain_album_gain[256] = "";
+    char replaygain_album_peak[256] = "";
+    char replaygain_track_gain[256] = "";
+    char replaygain_track_peak[256] = "";
+
+    char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255];
+    memset (extra_tags, 0, sizeof (extra_tags));
+    extra_tag_index = 0;
+
+    int have_track = 0;
+
+    DB_playItem_t *prev = NULL;
+    DB_playItem_t *it = NULL;
+
+    p = buffer;
+
+    deadbeef->pl_lock();
+    // ___null = deadbeef ignores external and internal cue files
+    deadbeef->plt_set_cue_file("___null");
+
+    while (p < end) {
+        p = skipspaces (p, end);
+        if (p >= end) {
+            break;
+        }
+
+        if (!strncasecmp (p, "FILE ", 5)) {
+            pl_get_qvalue_from_cue (p + 5, sizeof (file), file, charset);
+            if (file[0] == '/') { //full path
+                trace ("pl_insert_cue: adding file %s\n", file);
+                it = deadbeef->plt_insert_file2 (0, plt, after, file, pabort, cb, user_data);
+            }
+            else {
+                int l = strlen(cue_file_dir) + strlen (file) + 10;
+                char fullpath[l];
+                snprintf(fullpath, sizeof(fullpath), "%s/%s", cue_file_dir, file);
+                trace ("pl_insert_cue: adding file %s\n", fullpath);
+                it = deadbeef->plt_insert_file2 (0, plt, after, fullpath, pabort, cb, user_data);
+            }
+            if (it) {
+                if (prev) {
+                    // add previous track
+                    trace("adding info to %s",fname);
+                    plt_process_cue_track2 (prev, fname, track, index00, index01, pregap, title, albumperformer, performer, albumsongwriter, songwriter, albumtitle, replaygain_album_gain, replaygain_album_peak, replaygain_track_gain, replaygain_track_peak, totaltracks, extra_tags);
+                }
+                // reset per-track fields
+                track[0] = 0;
+                title[0] = 0;
+                pregap[0] = 0;
+                index00[0] = 0;
+                index01[0] = 0;
+                replaygain_track_gain[0] = 0;
+                replaygain_track_peak[0] = 0;
+                performer[0] = 0;
+                songwriter[0] = 0;
+
+                after = it;
+                prev = it;
+            }
+
+        }
+        else if (!strncasecmp (p, "TRACK ", 6)) {
+            pl_get_value_from_cue (p + 6, sizeof (track), track);
+            have_track = 1;
+        }
+        else if (!strncasecmp (p, "PERFORMER ", 10)) {
+            if (!track[0]) {
+                pl_get_qvalue_from_cue (p + 10, sizeof (albumperformer), albumperformer, charset);
+            }
+            else {
+                pl_get_qvalue_from_cue (p + 10, sizeof (performer), performer, charset);
+            }
+        }
+        else if (!strncasecmp (p, "SONGWRITER ", 11)) {
+            if (!track[0]) {
+                pl_get_qvalue_from_cue (p + 11, sizeof (albumsongwriter), albumsongwriter, charset);
+            }
+            else {
+                pl_get_qvalue_from_cue (p + 11, sizeof (songwriter), songwriter, charset);
+            }
+        }
+        else if (!strncasecmp (p, "TITLE ", 6)) {
+            if (!have_track && !albumtitle[0]) {
+                pl_get_qvalue_from_cue (p + 6, sizeof (albumtitle), albumtitle, charset);
+            }
+            else {
+                pl_get_qvalue_from_cue (p + 6, sizeof (title), title, charset);
+            }
+        }
+        else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_GAIN ", 26)) {
+            pl_get_value_from_cue (p + 26, sizeof (replaygain_album_gain), replaygain_album_gain);
+        }
+        else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_PEAK ", 26)) {
+            pl_get_value_from_cue (p + 26, sizeof (replaygain_album_peak), replaygain_album_peak);
+        }
+        else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_GAIN ", 26)) {
+            pl_get_value_from_cue (p + 26, sizeof (replaygain_track_gain), replaygain_track_gain);
+        }
+        else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_PEAK ", 26)) {
+            pl_get_value_from_cue (p + 26, sizeof (replaygain_track_peak), replaygain_track_peak);
+        }
+        else if (!strncasecmp (p, "PREGAP ", 7)) {
+            pl_get_value_from_cue (p + 7, sizeof (pregap), pregap);
+        }
+        else if (!strncasecmp (p, "INDEX 00 ", 9)) {
+            pl_get_value_from_cue (p + 9, sizeof (index00), index00);
+        }
+        else if (!strncasecmp (p, "INDEX 01 ", 9)) {
+            pl_get_value_from_cue (p + 9, sizeof (index01), index01);
+        }
+        else {
+            // determine and get extra tags
+            if (!have_track) {
+                for (int m = 0; cue_field_map[m]; m += 2) {
+                    if (!strncasecmp (p, cue_field_map[m], strlen(cue_field_map[m]))) {
+                        strcpy(extra_tags[extra_tag_index],cue_field_map[m+1]);
+                        pl_get_qvalue_from_cue (p + strlen(cue_field_map[m]), sizeof(extra_tags[extra_tag_index+1]), extra_tags[extra_tag_index+1], charset);
+                        extra_tag_index += 2;
+                        continue;
+                    }
+                }
+            }
+//          fprintf (stderr, "got unknown line:\n%s\n", p);
+        } /* end of while loop */
+
+        if (pabort && *pabort) {
+            deadbeef->plt_unset_cue_file();
+            deadbeef->pl_unlock();
+            free (membuffer);
+            return after;
+        }
+        // move pointer to the next line
+        while (p < end && *p >= 0x20) {
+           p++;
+        }
+
+    } /* end of while loop */
+
+    if (it) {
+        // handle last track
+        plt_process_cue_track2 (it, fname, track, index00, index01, pregap, title, albumperformer, performer, albumsongwriter, songwriter, albumtitle, replaygain_album_gain, replaygain_album_peak, replaygain_track_gain, replaygain_track_peak, totaltracks, extra_tags);
+    }
+
+    deadbeef->plt_unset_cue_file();
+    deadbeef->pl_unlock();
+    trace ("leave pl_insert_cue\n");
+    free (membuffer);
+    return after;
+
+}
+
+static DB_playItem_t *
+cueplug_load (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname, int *pabort, int (*cb)(DB_playItem_t *it, void *data), void *user_data) {
+    char resolved_fname[PATH_MAX];
+    char *res = realpath (fname, resolved_fname);
+    if (res) {
+        fname = resolved_fname;
+    }
+    return load_cue (plt, after, fname, pabort, cb, user_data);
+}
+
+int
+cueplug_save (ddb_playlist_t *plt, const char *fname, DB_playItem_t *first, DB_playItem_t *last) {
+    FILE *fp = fopen (fname, "w+t");
+    if (!fp) {
+        return -1;
+    }
+
+    int tcount = 1;
+
+    DB_playItem_t *it = first;
+    deadbeef->pl_item_ref (it);
+    while (it) {
+        uint32_t flags = deadbeef->pl_get_item_flags (it);
+        if (flags & DDB_IS_SUBTRACK) {
+            // skip subtracks
+            if (deadbeef->pl_find_meta_int (it, ":TRACKNUM", 0)) {
+                DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+                deadbeef->pl_item_unref (it);
+                it = next;
+                continue;
+            }
+        }
+
+        deadbeef->pl_lock ();
+        {
+            const char *fname = deadbeef->pl_find_meta (it, ":URI");
+            const char *artist = deadbeef->pl_find_meta (it, "artist");
+            const char *title = deadbeef->pl_find_meta (it, "title");
+            const char *composer = deadbeef->pl_find_meta (it, "composer");
+            if (!composer) {
+                composer = deadbeef->pl_find_meta (it, "SONGWRITER");
+            }
+            fprintf (fp, "FILE \"%s\"\n", fname);
+            fprintf (fp, "  TRACK %02d AUDIO\n", tcount++);
+            if (title) {
+                fprintf (fp, "    TITLE \"%s\"\n", title);
+            }
+            if (artist) {
+                fprintf (fp, "    PERFORMER \"%s\"\n", artist);
+            }
+            if (composer) {
+                fprintf (fp, "    SONGWRITER \"%s\"\n", composer);
+            }
+            fprintf (fp, "    INDEX 01 00:00:00\n");
+        }
+        deadbeef->pl_unlock ();
+
+        if (it == last) {
+            break;
+        }
+        DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+        deadbeef->pl_item_unref (it);
+        it = next;
+    }
+    fclose (fp);
+
+    return 0;
+}
+
+static const char * exts[] = { "cue", NULL, };
+DB_playlist_t plugin = {
+    .plugin.api_vmajor = 1,
+    .plugin.api_vminor = 0,
+    .plugin.version_major = 1,
+    .plugin.version_minor = 0,
+    .plugin.type = DB_PLUGIN_PLAYLIST,
+    .plugin.id = "cue",
+    .plugin.name = "CUE playlist support",
+    .plugin.descr = "",
+    .plugin.copyright = 
+        "CUE playlist plugin for DeaDBeeF Player\n"
+        "Copyright (C) 2017 Alexey Yakovenko\n"
+        "\n"
+        "This software is provided 'as-is', without any express or implied\n"
+        "warranty.  In no event will the authors be held liable for any damages\n"
+        "arising from the use of this software.\n"
+        "\n"
+        "Permission is granted to anyone to use this software for any purpose,\n"
+        "including commercial applications, and to alter it and redistribute it\n"
+        "freely, subject to the following restrictions:\n"
+        "\n"
+        "1. The origin of this software must not be misrepresented; you must not\n"
+        " claim that you wrote the original software. If you use this software\n"
+        " in a product, an acknowledgment in the product documentation would be\n"
+        " appreciated but is not required.\n"
+        "\n"
+        "2. Altered source versions must be plainly marked as such, and must not be\n"
+        " misrepresented as being the original software.\n"
+        "\n"
+        "3. This notice may not be removed or altered from any source distribution.\n"
+    ,
+    .plugin.website = "http://deadbeef.sf.net",
+    .load = cueplug_load,
+//    .save = cueplug_save,
+    .extensions = exts,
+};
+
+DB_plugin_t *
+cue_load (DB_functions_t *api) {
+    deadbeef = api;
+    return &plugin.plugin;
+}

--- a/shared/cueutil.c
+++ b/shared/cueutil.c
@@ -1,0 +1,122 @@
+/*
+    DeaDBeeF -- the music player
+    Copyright (C) 2009-2017 Alexey Yakovenko and other contributors
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "cueutil.h"
+
+extern DB_functions_t *deadbeef;
+
+const uint8_t *
+pl_cue_skipspaces (const uint8_t *p) {
+    while (*p && *p <= ' ') {
+        p++;
+    }
+    return p;
+}
+
+void
+pl_get_qvalue_from_cue (const uint8_t *p, int sz, char *out, const char *charset) {
+    char *str = out;
+    if (*p == 0) {
+        *out = 0;
+        return;
+    }
+    p = pl_cue_skipspaces (p);
+    if (*p == 0) {
+        *out = 0;
+        return;
+    }
+
+    if (*p == '"') {
+        p++;
+        p = pl_cue_skipspaces (p);
+        while (*p && *p != '"' && sz > 1) {
+            sz--;
+            *out++ = *p++;
+        }
+        *out = 0;
+    }
+    else {
+        while (*p && *p >= 0x20) {
+            sz--;
+            *out++ = *p++;
+        }
+        out--;
+        while (out > str && *out == 0x20) {
+            out--;
+        }
+        out++;
+        *out = 0;
+    }
+
+    if (!charset) {
+        return;
+    }
+
+    // recode
+    size_t l = strlen (str);
+    if (l == 0) {
+        return;
+    }
+
+    char recbuf[l*10];
+    int res = deadbeef->junk_recode (str, (int)l, recbuf, (int)(sizeof (recbuf)-1), charset);
+    if (res >= 0) {
+        strcpy (str, recbuf);
+    }
+    else
+    {
+        strcpy (str, "<UNRECOGNIZED CHARSET>");
+    }
+}
+
+void
+pl_get_value_from_cue (const char *p, int sz, char *out) {
+    while (*p >= ' ' && sz > 1) {
+        sz--;
+        *out++ = *p++;
+    }
+    while (out > p && (*(out-1) == 0x20 || *(out-1) == 0x8)) {
+        out--;
+    }
+    *out = 0;
+}
+
+float
+pl_cue_parse_time (const char *p) {
+    char *endptr;
+    long mins = strtol(p, &endptr, 10);
+    if (endptr - p < 1 || *endptr != ':') {
+        return -1;
+    }
+    p = endptr + 1;
+    long sec = strtol(p, &endptr, 10);
+    if (endptr - p != 2 || *endptr != ':') {
+        return -1;
+    }
+    p = endptr + 1;
+    long frm = strtol(p, &endptr, 10);
+    if (endptr - p != 2 || *endptr != '\0') {
+        return -1;
+    }
+    return mins * 60.f + sec + frm / 75.f;
+}

--- a/shared/cueutil.c
+++ b/shared/cueutil.c
@@ -23,7 +23,32 @@
 
 #include "cueutil.h"
 
+#define trace(...) { fprintf(stderr, __VA_ARGS__); }
+//#define trace(fmt,...)
+
 extern DB_functions_t *deadbeef;
+
+const char *cue_field_map[] = {
+    "CATALOG ", "CATALOG",
+    "ISRC ", "ISRC",
+    "REM DATE ", "year",
+    "REM GENRE ", "genre",
+    "REM COMMENT ", "comment",
+    "REM COMPOSER ", "composer",
+    "REM DISCNUMBER ", "disc",
+    "REM TOTALDISCS ", "numdiscs",
+    "REM DISCID ", "DISCID",
+    NULL, NULL,
+};
+//#define MAX_EXTRA_TAGS_FROM_CUE ((sizeof(cue_field_map) / sizeof(cue_field_map[0])))
+
+const uint8_t *
+skipspaces (const uint8_t *p, const uint8_t *end) {
+    while (p < end && *p <= ' ') {
+        p++;
+    }
+    return p;
+}
 
 const uint8_t *
 pl_cue_skipspaces (const uint8_t *p) {
@@ -119,4 +144,181 @@ pl_cue_parse_time (const char *p) {
         return -1;
     }
     return mins * 60.f + sec + frm / 75.f;
+}
+
+void
+pl_cue_get_total_tracks_and_files(const uint8_t *buffer, const uint8_t *buffer_end, int *ncuefiles, int *ncuetracks) {
+    const uint8_t *p = buffer;
+    *ncuetracks = 0;
+    *ncuefiles = 0;
+    while (p < buffer_end) {
+        p = skipspaces (p, buffer_end);
+        if (p >= buffer_end) {
+            break;
+        }
+        if (!strncasecmp (p, "FILE ", 5)) {
+            *ncuefiles = *ncuefiles + 1;
+        }
+        if (!strncasecmp (p, "TRACK ", 6)) {
+            *ncuetracks = *ncuetracks + 1;
+        }
+        // move pointer to the next line
+        while (p < buffer_end && *p >= 0x20) {
+           p++;
+        }
+    }
+    trace("totaltracks: %d\n", *ncuetracks);
+    trace("totalfiles: %d\n", *ncuefiles);
+}
+
+void
+pl_cue_set_track_field_values(DB_playItem_t *it, char cuefields[CUE_MAX_FIELDS][255], char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255], int extra_tag_index) {
+    if (cuefields[CUE_FIELD_PERFORMER][0]) {
+        deadbeef->pl_add_meta (it, "artist", cuefields[CUE_FIELD_PERFORMER]);
+        if (cuefields[CUE_FIELD_ALBUM_PERFORMER][0] && strcmp (cuefields[CUE_FIELD_ALBUM_PERFORMER], cuefields[CUE_FIELD_PERFORMER])) {
+            deadbeef->pl_add_meta (it, "album artist", cuefields[CUE_FIELD_ALBUM_PERFORMER]);
+        }
+    }
+    else if (cuefields[CUE_FIELD_ALBUM_PERFORMER][0]) {
+        deadbeef->pl_add_meta (it, "artist", cuefields[CUE_FIELD_ALBUM_PERFORMER]);
+    }
+    if (cuefields[CUE_FIELD_SONGWRITER][0]) {
+        deadbeef->pl_add_meta (it, "SONGWRITER", cuefields[CUE_FIELD_SONGWRITER]);
+    }
+    else if (cuefields[CUE_FIELD_SONGWRITER][0]) {
+        deadbeef->pl_add_meta (it, "SONGWRITER", cuefields[CUE_FIELD_SONGWRITER]);
+    }
+    if (cuefields[CUE_FIELD_ALBUM_TITLE][0]) {
+        deadbeef->pl_add_meta (it, "album", cuefields[CUE_FIELD_ALBUM_TITLE]);
+    }
+    if (cuefields[CUE_FIELD_TRACK][0]) {
+        deadbeef->pl_add_meta (it, "track", cuefields[CUE_FIELD_TRACK]);
+    }
+    if (cuefields[CUE_FIELD_TITLE][0]) {
+        deadbeef->pl_add_meta (it, "title", cuefields[CUE_FIELD_TITLE]);
+    }
+    if (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN][0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMGAIN, atof (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN]));
+    }
+    if (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK][0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMPEAK, atof (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK]));
+    }
+    if (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN][0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKGAIN, atof (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN]));
+    }
+    if (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK][0]) {
+        deadbeef->pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKPEAK, atof (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK]));
+    }
+    // add extra tags to tracks
+    for (int y = 0; y < extra_tag_index; y += 2) {
+        if (extra_tags[y+1]) {
+            deadbeef->pl_add_meta (it, extra_tags[y], extra_tags[y+1]);
+        }
+    }
+    // generated "total tracks" field
+    deadbeef->pl_add_meta(it, "numtracks", cuefields[CUE_FIELD_TOTALTRACKS]);
+}
+
+void
+pl_cue_reset_per_track_fields(char cuefields[CUE_MAX_FIELDS][255]) {
+    //cuefields[CUE_FIELD_TRACK][0] = 0;
+    cuefields[CUE_FIELD_TITLE][0] = 0;
+    cuefields[CUE_FIELD_PREGAP][0] = 0;
+    cuefields[CUE_FIELD_INDEX00][0] = 0;
+    cuefields[CUE_FIELD_INDEX01][0] = 0;
+    cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN][0] = 0;
+    cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK][0] = 0;
+    cuefields[CUE_FIELD_PERFORMER][0] = 0;
+    cuefields[CUE_FIELD_SONGWRITER][0] = 0;
+}
+
+// success:
+//    CUE_FIELD_*
+// error:
+//    -1
+int
+pl_cue_get_field_value(const char *p, char cuefields[CUE_MAX_FIELDS][255], char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255], const char *charset, int have_track, int *extra_tag_index) {
+    if (!strncasecmp (p, "FILE ", 5)) {
+        pl_get_qvalue_from_cue (p + 5, sizeof (cuefields[CUE_FIELD_FILE]), cuefields[CUE_FIELD_FILE], charset);
+        return CUE_FIELD_FILE;
+    }
+    else if (!strncasecmp (p, "TRACK ", 6)) {
+        // this requires some post-processing
+        // and the previous value must previous value must not be lost..
+        //pl_get_value_from_cue (p + 6, sizeof (cuefields[CUE_FIELD_TRACK]), cuefields[CUE_FIELD_TRACK]);
+        return CUE_FIELD_TRACK;
+    }
+    else if (!strncasecmp (p, "PERFORMER ", 10)) {
+        if (!cuefields[CUE_FIELD_TRACK][0]) {
+            pl_get_qvalue_from_cue (p + 10, sizeof (cuefields[CUE_FIELD_ALBUM_PERFORMER]), cuefields[CUE_FIELD_ALBUM_PERFORMER], charset);
+            return CUE_FIELD_ALBUM_PERFORMER;
+        }
+        else {
+             pl_get_qvalue_from_cue (p + 10, sizeof (cuefields[CUE_FIELD_PERFORMER]), cuefields[CUE_FIELD_PERFORMER], charset);
+             return CUE_FIELD_PERFORMER;
+        }
+    }
+    else if (!strncasecmp (p, "SONGWRITER ", 11)) {
+        if (!cuefields[CUE_FIELD_TRACK][0]) {
+            pl_get_qvalue_from_cue (p + 11, sizeof (cuefields[CUE_FIELD_ALBUM_SONGWRITER]), cuefields[CUE_FIELD_ALBUM_SONGWRITER], charset);
+            return CUE_FIELD_ALBUM_SONGWRITER;
+        }
+        else {
+            pl_get_qvalue_from_cue (p + 11, sizeof (cuefields[CUE_FIELD_SONGWRITER]), cuefields[CUE_FIELD_SONGWRITER], charset);
+            return CUE_FIELD_SONGWRITER;
+        }
+    }
+    else if (!strncasecmp (p, "TITLE ", 6)) {
+        if (!have_track && !cuefields[CUE_FIELD_ALBUM_TITLE][0]) {
+            pl_get_qvalue_from_cue (p + 6, sizeof (cuefields[CUE_FIELD_ALBUM_TITLE]), cuefields[CUE_FIELD_ALBUM_TITLE], charset);
+            return CUE_FIELD_ALBUM_TITLE;
+        }
+        else {
+            pl_get_qvalue_from_cue (p + 6, sizeof (cuefields[CUE_FIELD_TITLE]), cuefields[CUE_FIELD_TITLE], charset);
+            return CUE_FIELD_TITLE;
+        }
+    }
+    else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_GAIN ", 26)) {
+        pl_get_value_from_cue (p + 26, sizeof (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN]), cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN]);
+        return CUE_FIELD_REPLAYGAIN_ALBUM_GAIN;
+    }
+    else if (!strncasecmp (p, "REM REPLAYGAIN_ALBUM_PEAK ", 26)) {
+        pl_get_value_from_cue (p + 26, sizeof (cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK]), cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK]);
+        return CUE_FIELD_REPLAYGAIN_ALBUM_PEAK;
+    }
+    else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_GAIN ", 26)) {
+        pl_get_value_from_cue (p + 26, sizeof (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN]), cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN]);
+        return CUE_FIELD_REPLAYGAIN_TRACK_GAIN;
+    }
+    else if (!strncasecmp (p, "REM REPLAYGAIN_TRACK_PEAK ", 26)) {
+        pl_get_value_from_cue (p + 26, sizeof (cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK]), cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK]);
+        return CUE_FIELD_REPLAYGAIN_TRACK_PEAK;
+    }
+    else if (!strncasecmp (p, "PREGAP ", 7)) {
+        pl_get_value_from_cue (p + 7, sizeof (cuefields[CUE_FIELD_PREGAP]), cuefields[CUE_FIELD_PREGAP]);
+        return CUE_FIELD_PREGAP;
+    }
+    else if (!strncasecmp (p, "INDEX 00 ", 9)) {
+        pl_get_value_from_cue (p + 9, sizeof (cuefields[CUE_FIELD_INDEX00]), cuefields[CUE_FIELD_INDEX00]);
+        return CUE_FIELD_INDEX00;
+    }
+    else if (!strncasecmp (p, "INDEX 01 ", 9)) {
+        pl_get_value_from_cue (p + 9, sizeof (cuefields[CUE_FIELD_INDEX01]), cuefields[CUE_FIELD_INDEX01]);
+        return CUE_FIELD_INDEX01;
+    }
+    else {
+        // determine and get extra tags
+        if (!have_track) {
+            for (int m = 0; cue_field_map[m]; m += 2) {
+                if (!strncasecmp (p, cue_field_map[m], strlen(cue_field_map[m]))) {
+                    strcpy(extra_tags[*extra_tag_index],cue_field_map[m+1]);
+                    pl_get_qvalue_from_cue (p + strlen(cue_field_map[m]), sizeof(extra_tags[*extra_tag_index+1]), extra_tags[*extra_tag_index+1], charset);
+                    *extra_tag_index = *extra_tag_index + 2;
+                    return CUE_MAX_FIELDS;
+                }
+            }
+        }
+        return -1;
+//      fprintf (stderr, "got unknown line:\n%s\n", p);
+    }
 }

--- a/shared/cueutil.h
+++ b/shared/cueutil.h
@@ -35,6 +35,32 @@
 #define SKIP_BLANK_CUE_TRACKS 0
 #define MAX_CUE_TRACKS 99
 
+extern const char *cue_field_map[];
+#define MAX_EXTRA_TAGS_FROM_CUE 18 //((sizeof(cue_field_map) / sizeof(cue_field_map[0])))
+
+enum {
+    CUE_FIELD_ALBUM_PERFORMER,
+    CUE_FIELD_PERFORMER,
+    CUE_FIELD_ALBUM_SONGWRITER,
+    CUE_FIELD_SONGWRITER,
+    CUE_FIELD_ALBUM_TITLE,
+    CUE_FIELD_FILE,
+    CUE_FIELD_TRACK,
+    CUE_FIELD_TITLE,
+    CUE_FIELD_PREGAP,
+    CUE_FIELD_INDEX00,
+    CUE_FIELD_INDEX01,
+    CUE_FIELD_REPLAYGAIN_ALBUM_GAIN,
+    CUE_FIELD_REPLAYGAIN_ALBUM_PEAK,
+    CUE_FIELD_REPLAYGAIN_TRACK_GAIN,
+    CUE_FIELD_REPLAYGAIN_TRACK_PEAK,
+    CUE_FIELD_TOTALTRACKS,
+    CUE_MAX_FIELDS,
+};
+
+const uint8_t *
+skipspaces (const uint8_t *p, const uint8_t *end);
+
 const uint8_t *
 pl_cue_skipspaces (const uint8_t *p);
 
@@ -46,5 +72,17 @@ pl_get_value_from_cue (const char *p, int sz, char *out);
 
 float
 pl_cue_parse_time (const char *p);
+
+void
+pl_cue_get_total_tracks_and_files(const uint8_t *buffer, const uint8_t *buffersize, int *ncuefiles, int *ncuetracks);
+
+void
+pl_cue_set_track_field_values(DB_playItem_t *it, char cuefields[CUE_MAX_FIELDS][255], char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255], int extra_tag_index);
+
+void
+pl_cue_reset_per_track_fields(char cuefields[CUE_MAX_FIELDS][255]);
+
+int
+pl_cue_get_field_value(const char *p, char cuefields[CUE_MAX_FIELDS][255], char extra_tags[MAX_EXTRA_TAGS_FROM_CUE][255], const char *charset, int have_track, int *extra_tag_index);
 
 #endif /* cueutil_h */

--- a/shared/cueutil.h
+++ b/shared/cueutil.h
@@ -1,0 +1,50 @@
+/*
+    DeaDBeeF -- the music player
+    Copyright (C) 2017 Alexey Yakovenko and other contributors
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef cueutil_h
+#define cueutil_h
+
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "../deadbeef.h"
+
+#define SKIP_BLANK_CUE_TRACKS 0
+#define MAX_CUE_TRACKS 99
+
+const uint8_t *
+pl_cue_skipspaces (const uint8_t *p);
+
+void
+pl_get_qvalue_from_cue (const uint8_t *p, int sz, char *out, const char *charset);
+
+void
+pl_get_value_from_cue (const char *p, int sz, char *out);
+
+float
+pl_cue_parse_time (const char *p);
+
+#endif /* cueutil_h */


### PR DESCRIPTION
I've had this code for a while and thought i should open a pull request before it gets lost..

This adds support for opnening *.cue files directly.

With this plugin cue support can be considered complete (in a basic level, because i remember seeing foobar2000 do advanced stuff even with tracks+cue stuff).

Features:
- tracks+cue  support (tags + replaygain, lacking everything else)
- cdimage+cue support (new api (hacks)* to get playlist.c do the required stuff..)

	plt_set_cue_file(const char *filename)
	plt_unset_cue_file(void)

There's also the ability to save playlists in cue format, but it's disabled.
It can be enabled if the auto totaltracks stuff is removed.. but i'm not sure.

cdimage+cue
------------
If only 1 file is detected then:
- set the internal deadbeef cue_file variable
- insert audio_file to playlist
- expect decoders to call deadbeef->plt_insert_cue_int(...), or plt_process_cue
- unset cue_file

tracks+cue
-----------
- 1 file can only have 1 track. 1 = 1
- to prevent deadbeef from loading external or internal cuesheets associated with the audio files referenced by the current cuesheet being processed by the plugin.. set a special value: "___null"
- and make playlist.c stop processing cue stuff while cue_file = "___null"
- unset cue_file after finishing processing the cuesheet.

