### PR TITLE
(cdimage+cue) support showing subindexes as separate tracks in playlist

### DIFF
--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1390,3 +1390,7 @@ void
 on_listview_group_spacing_value_changed
                                         (GtkSpinButton   *spinbutton,
                                         gpointer         user_data);
+
+void
+on_cue_subindexes_as_tracks_toggled            (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -3889,6 +3889,26 @@ Only prevent clipping</property>
 		  </child>
 
 		  <child>
+		    <widget class="GtkCheckButton" id="chkbox_cue_subindexes">
+		      <property name="visible">True</property>
+		      <property name="can_focus">True</property>
+		      <property name="label" translatable="yes">CUE: show subindexes as tracks (INDEX 02, INDEX 03, etc)</property>
+		      <property name="use_underline">True</property>
+		      <property name="relief">GTK_RELIEF_NORMAL</property>
+		      <property name="focus_on_click">True</property>
+		      <property name="active">False</property>
+		      <property name="inconsistent">False</property>
+		      <property name="draw_indicator">True</property>
+		      <signal name="toggled" handler="on_cue_subindexes_as_tracks_toggled" last_modification_time="Thu, 15 Jun 2017 16:26:16 GMT"/>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
+		      <property name="fill">False</property>
+		    </packing>
+		  </child>
+
+		  <child>
 		    <widget class="GtkHBox" id="hbox141">
 		      <property name="visible">True</property>
 		      <property name="homogeneous">False</property>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1609,6 +1609,7 @@ create_prefwin (void)
   GtkWidget *hide_delete_from_disk;
   GtkWidget *auto_name_playlist_from_folder;
   GtkWidget *auto_size_columns;
+  GtkWidget *chkbox_cue_subindexes;
   GtkWidget *hbox141;
   GtkWidget *label164;
   GObject *listview_group_spacing_adj;
@@ -2161,6 +2162,10 @@ create_prefwin (void)
   auto_size_columns = gtk_check_button_new_with_mnemonic (_("Auto-resize columns to fit the window"));
   gtk_widget_show (auto_size_columns);
   gtk_box_pack_start (GTK_BOX (vbox44), auto_size_columns, FALSE, FALSE, 0);
+
+  chkbox_cue_subindexes = gtk_check_button_new_with_mnemonic (_("CUE: show subindexes as tracks (INDEX 02, INDEX 03, etc)"));
+  gtk_widget_show (chkbox_cue_subindexes);
+  gtk_box_pack_start (GTK_BOX (vbox44), chkbox_cue_subindexes, FALSE, FALSE, 0);
 
   hbox141 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox141);
@@ -3097,6 +3102,9 @@ create_prefwin (void)
   g_signal_connect ((gpointer) auto_size_columns, "toggled",
                     G_CALLBACK (on_auto_size_columns_toggled),
                     NULL);
+  g_signal_connect ((gpointer) chkbox_cue_subindexes, "toggled",
+                    G_CALLBACK (on_cue_subindexes_as_tracks_toggled),
+                    NULL);
   g_signal_connect ((gpointer) listview_group_spacing, "value_changed",
                     G_CALLBACK (on_listview_group_spacing_value_changed),
                     NULL);
@@ -3353,6 +3361,7 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, hide_delete_from_disk, "hide_delete_from_disk");
   GLADE_HOOKUP_OBJECT (prefwin, auto_name_playlist_from_folder, "auto_name_playlist_from_folder");
   GLADE_HOOKUP_OBJECT (prefwin, auto_size_columns, "auto_size_columns");
+  GLADE_HOOKUP_OBJECT (prefwin, chkbox_cue_subindexes, "chkbox_cue_subindexes");
   GLADE_HOOKUP_OBJECT (prefwin, hbox141, "hbox141");
   GLADE_HOOKUP_OBJECT (prefwin, label164, "label164");
   GLADE_HOOKUP_OBJECT (prefwin, listview_group_spacing, "listview_group_spacing");

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -298,6 +298,9 @@ gtkui_run_preferences_dlg (void) {
     // enable auto-sizing of columns
     set_toggle_button("auto_size_columns", deadbeef->conf_get_int ("gtkui.autoresize_columns", 0));
 
+    // enable showing cue subindexes as tracks
+    set_toggle_button("chkbox_cue_subindexes", deadbeef->conf_get_int ("cue.subindexes_as_tracks", 0));
+
     gtk_spin_button_set_value(GTK_SPIN_BUTTON (lookup_widget (w, "listview_group_spacing")), deadbeef->conf_get_int ("playlist.groups.spacing", 0));
 
     // fill gui plugin list
@@ -1257,6 +1260,14 @@ on_auto_size_columns_toggled           (GtkToggleButton *togglebutton,
                                         gpointer         user_data)
 {
     deadbeef->conf_set_int ("gtkui.autoresize_columns", gtk_toggle_button_get_active (togglebutton));
+}
+
+void
+on_cue_subindexes_as_tracks_toggled           (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_int ("cue.subindexes_as_tracks", gtk_toggle_button_get_active (togglebutton));
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 
 void

--- a/shared/cueutil.c
+++ b/shared/cueutil.c
@@ -244,7 +244,7 @@ pl_cue_get_field_value(const char *p, char cuefields[CUE_MAX_FIELDS][255], char 
     }
     else if (!strncasecmp (p, "TRACK ", 6)) {
         // this requires some post-processing
-        // and the previous value must previous value must not be lost..
+        // and the previous value must not be lost..
         //pl_get_value_from_cue (p + 6, sizeof (cuefields[CUE_FIELD_TRACK]), cuefields[CUE_FIELD_TRACK]);
         return CUE_FIELD_TRACK;
     }
@@ -305,6 +305,13 @@ pl_cue_get_field_value(const char *p, char cuefields[CUE_MAX_FIELDS][255], char 
     else if (!strncasecmp (p, "INDEX 01 ", 9)) {
         pl_get_value_from_cue (p + 9, sizeof (cuefields[CUE_FIELD_INDEX01]), cuefields[CUE_FIELD_INDEX01]);
         return CUE_FIELD_INDEX01;
+    }
+    else if (!strncasecmp (p, "INDEX ", 6)) {
+        // INDEX 02, INDEX 03, INDEX 04, etc...
+        // for practical purposes, store value of INDEX XX in fields[CUE_FIELD_INDEX01]
+        // ( see playlist.c -> plt_process_cue_track()
+        pl_get_value_from_cue (p + 9, sizeof (cuefields[CUE_FIELD_INDEX01]), cuefields[CUE_FIELD_INDEX01]);
+        return CUE_FIELD_INDEX_X;
     }
     else {
         // determine and get extra tags

--- a/shared/cueutil.h
+++ b/shared/cueutil.h
@@ -58,6 +58,8 @@ enum {
     CUE_MAX_FIELDS,
 };
 
+#define CUE_FIELD_INDEX_X 100
+
 const uint8_t *
 skipspaces (const uint8_t *p, const uint8_t *end);
 


### PR DESCRIPTION
https://pastebin.com/raw/PRuTEkGz

cuesheets from some CDs ripped with EAC might have
 TRACK "01" AUDIO
   TITLE "title"
   INDEX 01 00:00:00
   INDEX 02 01:30:00
   INDEX 03 02:00:00
   INDEX 04 02:49:00
    etc..

INDEX 02+ are ignored by basically every player i tried, including fb2k.

Mostly found in OSTs and symphonic/progressive stuff.
(http://forums.stevehoffman.tv/threads/question-about-song-indexing-in-older-maybe-newer-cd-players.253955/)

These extra indexes or "subindexes" usually describe a new section, a different melody... another "track" within the same track.. !

There's a new setting "cue.subindexes_as_tracks" and a gtkui checkbox to enable or disable it (it's disabled by default).

Menu Edit-> Preferences-> GUI/Misc -> Playlist-> CUE: show subindexes as tracks...

If it's enabled and one of those special cuesheets is detected, the playlist will look like this:
Title
Title_02
Title_03
Title_04
etc

With this file you can test this new feature only for VIPs..
https://expirebox.com/download/7f64d16d618ab40d52e010282ca7ab37.html
