### PR TITLE
main: call pl_init() after conf_init()

### DIFF
--- a/main.c
+++ b/main.c
@@ -1120,9 +1120,9 @@ main (int argc, char *argv[]) {
         return 0;
     }
 
-    pl_init ();
     conf_init ();
     conf_load (); // required by some plugins at startup
+    pl_init ();
 
     if (use_gui_plugin[0]) {
         conf_set_str ("gui_plugin", use_gui_plugin);


### PR DESCRIPTION
The best way to initialize a (playlist.c) variable read from the config file is in pl_init(), but deadbeef segfaults because conf_get_* tries to lock a mutex that is created in conf_init().

This fixes that issue..