### PR TITLE
hotkeys: add "move tracks up/down" option

### DIFF
--- a/plugins/hotkeys/actionhandlers.c
+++ b/plugins/hotkeys/actionhandlers.c
@@ -608,14 +608,14 @@ action_toggle_in_playqueue_handler (DB_plugin_action_t *act, int ctx) {
 }
 
 int
-action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx){
+action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx) {
     deadbeef->pl_lock ();
 
     ddb_playlist_t *plt = deadbeef->action_get_playlist ();
     DB_playItem_t *it;
 
     int it_count = 0;
-    if (ctx == DDB_ACTION_CTX_SELECTION){
+    if (ctx == DDB_ACTION_CTX_SELECTION) {
         it_count = deadbeef->pl_getselcount ();
         if (it_count) {
             int i=0;
@@ -632,20 +632,20 @@ action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx){
                 it = next;
             }
             DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]-1);
-            if (drop_before){
+            if (drop_before) {
                 deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
                 deadbeef->pl_item_unref (drop_before);
             }
         }
     }
-    else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
+    else if (ctx == DDB_ACTION_CTX_NOWPLAYING) {
         it = deadbeef->streamer_get_playing_track ();
-        if (it){
+        if (it) {
             it_count = 1;
             uint32_t indexes[1];
             indexes[0] = deadbeef->pl_get_idx_of(it);
             DB_playItem_t *drop_before = deadbeef->pl_get_prev (it,PL_MAIN);
-            if(drop_before){
+            if(drop_before) {
                 deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
                 deadbeef->pl_item_unref (drop_before);
             }
@@ -661,14 +661,14 @@ action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx){
 }
 
 int
-action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx){
+action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx) {
     deadbeef->pl_lock ();
 
     ddb_playlist_t *plt = deadbeef->action_get_playlist ();
     DB_playItem_t *it;
 
     int it_count = 0;
-    if (ctx == DDB_ACTION_CTX_SELECTION){
+    if (ctx == DDB_ACTION_CTX_SELECTION) {
         int it_count = deadbeef->pl_getselcount ();
         if (it_count) {
             int i=0;
@@ -690,9 +690,9 @@ action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx){
                 deadbeef->pl_item_unref (drop_before);
         }
     }
-    else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
+    else if (ctx == DDB_ACTION_CTX_NOWPLAYING) {
         it = deadbeef->streamer_get_playing_track ();
-        if (it){
+        if (it) {
             it_count = 1;
             uint32_t indexes[1];
             indexes[0] = deadbeef->pl_get_idx_of(it);

--- a/plugins/hotkeys/actionhandlers.c
+++ b/plugins/hotkeys/actionhandlers.c
@@ -604,7 +604,106 @@ action_toggle_in_playqueue_handler (DB_plugin_action_t *act, int ctx) {
     }
 
     deadbeef->plt_unref (plt);
+    return 0;
+}
 
+int
+action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx){
+    deadbeef->pl_lock ();
+
+    ddb_playlist_t *plt = deadbeef->action_get_playlist ();
+    DB_playItem_t *it;
+
+    int it_count = 0;
+    if (ctx == DDB_ACTION_CTX_SELECTION){
+        it_count = deadbeef->pl_getselcount ();
+        int i=0;
+        uint32_t indexes[it_count];
+
+        it = deadbeef->plt_get_first (plt, PL_MAIN);
+        while (it) {
+            if (deadbeef->pl_is_selected (it)) {
+                indexes[i] = deadbeef->pl_get_idx_of (it);
+                i++;
+            }
+            DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+            deadbeef->pl_item_unref (it);
+            it = next;
+        }
+        DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]-1);
+        if (drop_before){
+            deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+            deadbeef->pl_item_unref (drop_before);
+        }
+    }
+    else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
+        it = deadbeef->streamer_get_playing_track ();
+        if (it){
+            it_count = 1;
+            uint32_t indexes[1];
+            indexes[0] = deadbeef->pl_get_idx_of(it);
+            DB_playItem_t *drop_before = deadbeef->pl_get_prev (it,PL_MAIN);
+            if(drop_before){
+                deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+                deadbeef->pl_item_unref (drop_before);
+            }
+            deadbeef->pl_item_unref(it);
+        }
+    }
+
+    deadbeef->plt_save_config (plt);
+    deadbeef->plt_unref (plt);
+    deadbeef->pl_unlock ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    return 0;
+}
+
+int
+action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx){
+    deadbeef->pl_lock ();
+
+    ddb_playlist_t *plt = deadbeef->action_get_playlist ();
+    DB_playItem_t *it;
+
+    int it_count = 0;
+    if (ctx == DDB_ACTION_CTX_SELECTION){
+        int it_count = deadbeef->pl_getselcount ();
+        int i=0;
+        uint32_t indexes[it_count];
+
+        it = deadbeef->plt_get_first (plt, PL_MAIN);
+        while (it) {
+            if (deadbeef->pl_is_selected (it)) {
+                indexes[i] = deadbeef->pl_get_idx_of (it);
+                i++;
+            }
+            DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+            deadbeef->pl_item_unref (it);
+            it = next;
+        }
+        DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[i-1]+2);
+        deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+        if(drop_before)
+            deadbeef->pl_item_unref (drop_before);
+    }
+    else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
+        it = deadbeef->streamer_get_playing_track ();
+        if (it){
+            it_count = 1;
+            uint32_t indexes[1];
+            indexes[0] = deadbeef->pl_get_idx_of(it);
+            DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]+2);
+            deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+            if(drop_before)
+                deadbeef->pl_item_unref (drop_before);
+            deadbeef->pl_item_unref(it);
+        }
+    }
+
+    deadbeef->plt_save_config (plt);
+    deadbeef->plt_unref (plt);
+    deadbeef->pl_unlock ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
     return 0;
 }
 

--- a/plugins/hotkeys/actionhandlers.c
+++ b/plugins/hotkeys/actionhandlers.c
@@ -618,7 +618,7 @@ action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx) {
     if (ctx == DDB_ACTION_CTX_SELECTION) {
         it_count = deadbeef->pl_getselcount ();
         if (it_count) {
-            int i=0;
+            int i = 0;
             uint32_t indexes[it_count];
 
             it = deadbeef->plt_get_first (plt, PL_MAIN);
@@ -643,13 +643,13 @@ action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx) {
         if (it) {
             it_count = 1;
             uint32_t indexes[1];
-            indexes[0] = deadbeef->pl_get_idx_of(it);
+            indexes[0] = deadbeef->pl_get_idx_of (it);
             DB_playItem_t *drop_before = deadbeef->pl_get_prev (it,PL_MAIN);
-            if(drop_before) {
+            if (drop_before) {
                 deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
                 deadbeef->pl_item_unref (drop_before);
             }
-            deadbeef->pl_item_unref(it);
+            deadbeef->pl_item_unref (it);
         }
     }
 
@@ -671,7 +671,7 @@ action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx) {
     if (ctx == DDB_ACTION_CTX_SELECTION) {
         int it_count = deadbeef->pl_getselcount ();
         if (it_count) {
-            int i=0;
+            int i = 0;
             uint32_t indexes[it_count];
 
             it = deadbeef->plt_get_first (plt, PL_MAIN);
@@ -686,7 +686,7 @@ action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx) {
             }
             DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[i-1]+2);
             deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
-            if(drop_before)
+            if (drop_before)
                 deadbeef->pl_item_unref (drop_before);
         }
     }
@@ -695,12 +695,12 @@ action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx) {
         if (it) {
             it_count = 1;
             uint32_t indexes[1];
-            indexes[0] = deadbeef->pl_get_idx_of(it);
+            indexes[0] = deadbeef->pl_get_idx_of (it);
             DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]+2);
             deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
-            if(drop_before)
+            if (drop_before)
                 deadbeef->pl_item_unref (drop_before);
-            deadbeef->pl_item_unref(it);
+            deadbeef->pl_item_unref (it);
         }
     }
 

--- a/plugins/hotkeys/actionhandlers.c
+++ b/plugins/hotkeys/actionhandlers.c
@@ -617,23 +617,25 @@ action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx){
     int it_count = 0;
     if (ctx == DDB_ACTION_CTX_SELECTION){
         it_count = deadbeef->pl_getselcount ();
-        int i=0;
-        uint32_t indexes[it_count];
+        if (it_count) {
+            int i=0;
+            uint32_t indexes[it_count];
 
-        it = deadbeef->plt_get_first (plt, PL_MAIN);
-        while (it) {
-            if (deadbeef->pl_is_selected (it)) {
-                indexes[i] = deadbeef->pl_get_idx_of (it);
-                i++;
+            it = deadbeef->plt_get_first (plt, PL_MAIN);
+            while (it) {
+                if (deadbeef->pl_is_selected (it)) {
+                    indexes[i] = deadbeef->pl_get_idx_of (it);
+                    i++;
+                }
+                DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+                deadbeef->pl_item_unref (it);
+                it = next;
             }
-            DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
-            deadbeef->pl_item_unref (it);
-            it = next;
-        }
-        DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]-1);
-        if (drop_before){
-            deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
-            deadbeef->pl_item_unref (drop_before);
+            DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[0]-1);
+            if (drop_before){
+                deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+                deadbeef->pl_item_unref (drop_before);
+            }
         }
     }
     else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
@@ -668,23 +670,25 @@ action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx){
     int it_count = 0;
     if (ctx == DDB_ACTION_CTX_SELECTION){
         int it_count = deadbeef->pl_getselcount ();
-        int i=0;
-        uint32_t indexes[it_count];
+        if (it_count) {
+            int i=0;
+            uint32_t indexes[it_count];
 
-        it = deadbeef->plt_get_first (plt, PL_MAIN);
-        while (it) {
-            if (deadbeef->pl_is_selected (it)) {
-                indexes[i] = deadbeef->pl_get_idx_of (it);
-                i++;
+            it = deadbeef->plt_get_first (plt, PL_MAIN);
+            while (it) {
+                if (deadbeef->pl_is_selected (it)) {
+                    indexes[i] = deadbeef->pl_get_idx_of (it);
+                    i++;
+                }
+                DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
+                deadbeef->pl_item_unref (it);
+                it = next;
             }
-            DB_playItem_t *next = deadbeef->pl_get_next (it, PL_MAIN);
-            deadbeef->pl_item_unref (it);
-            it = next;
+            DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[i-1]+2);
+            deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
+            if(drop_before)
+                deadbeef->pl_item_unref (drop_before);
         }
-        DB_playItem_t *drop_before = deadbeef->pl_get_for_idx (indexes[i-1]+2);
-        deadbeef->plt_move_items (plt, PL_MAIN, plt, drop_before, indexes, it_count);
-        if(drop_before)
-            deadbeef->pl_item_unref (drop_before);
     }
     else if (ctx == DDB_ACTION_CTX_NOWPLAYING){
         it = deadbeef->streamer_get_playing_track ();

--- a/plugins/hotkeys/actionhandlers.h
+++ b/plugins/hotkeys/actionhandlers.h
@@ -118,6 +118,12 @@ int
 action_toggle_in_playqueue_handler (DB_plugin_action_t *act, int ctx);
 
 int
+action_move_tracks_up_handler (DB_plugin_action_t *act, int ctx);
+
+int
+action_move_tracks_down_handler (DB_plugin_action_t *act, int ctx);
+
+int
 action_add_to_playqueue_handler (DB_plugin_action_t *act, int ctx);
 
 int

--- a/plugins/hotkeys/hotkeys.c
+++ b/plugins/hotkeys/hotkeys.c
@@ -1078,12 +1078,28 @@ static DB_plugin_action_t action_toggle_in_playqueue = {
     .next = &action_add_to_playqueue
 };
 
+static DB_plugin_action_t action_move_tracks_down = {
+    .title = "Move/Move Tracks down",
+    .name = "move_tracks_down",
+    .flags = DB_ACTION_MULTIPLE_TRACKS,
+    .callback2 = action_move_tracks_down_handler,
+    .next = &action_toggle_in_playqueue
+};
+
+static DB_plugin_action_t action_move_tracks_up = {
+    .title = "Move/Move Tracks up",
+    .name = "move_tracks_up",
+    .flags = DB_ACTION_MULTIPLE_TRACKS,
+    .callback2 = action_move_tracks_up_handler,
+    .next = &action_move_tracks_down
+};
+
 static DB_plugin_action_t action_toggle_mute = {
     .title = "Playback/Toggle Mute",
     .name = "toggle_mute",
     .flags = DB_ACTION_COMMON,
     .callback2 = action_toggle_mute_handler,
-    .next = &action_toggle_in_playqueue
+    .next = &action_move_tracks_up
 };
 
 static DB_plugin_action_t action_play = {

--- a/plugins/hotkeys/hotkeys.c
+++ b/plugins/hotkeys/hotkeys.c
@@ -1079,7 +1079,7 @@ static DB_plugin_action_t action_toggle_in_playqueue = {
 };
 
 static DB_plugin_action_t action_move_tracks_down = {
-    .title = "Move/Move Tracks down",
+    .title = "Move/Move Tracks Down",
     .name = "move_tracks_down",
     .flags = DB_ACTION_MULTIPLE_TRACKS,
     .callback2 = action_move_tracks_down_handler,
@@ -1087,7 +1087,7 @@ static DB_plugin_action_t action_move_tracks_down = {
 };
 
 static DB_plugin_action_t action_move_tracks_up = {
-    .title = "Move/Move Tracks up",
+    .title = "Move/Move Tracks Up",
     .name = "move_tracks_up",
     .flags = DB_ACTION_MULTIPLE_TRACKS,
     .callback2 = action_move_tracks_up_handler,


### PR DESCRIPTION
Adds option to move tracks with hotkeys. Works with selection and nowplaying. Has no action for whole playlist (obviously).
I had some problems with understanding how `plt_move_items()` works but I hope I got it right.

I think it would close #1667. Eventually I can add Ctrl+Alt+Up and Ctrl+Alt+Down as default keys for moving songs.