### PR TITLE
travis: require sudo for linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     include:
         - os: linux
           dist: trusty
+          sudo: required
         - os: osx
           osx_image: xcode8.3
 


### PR DESCRIPTION
This will ensure that cloned deadbeef repos will include sudo which is missing by default.